### PR TITLE
add CLI, Ansible, Chef, and Helm chart install methods for DB NRDOT monitoring

### DIFF
--- a/src/content/docs/opentelemetry/database/mssql/ansible.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/ansible.mdx
@@ -1,0 +1,422 @@
+---
+title: "Ansible install for MSSQL monitoring with NRDOT"
+tags:
+  - OpenTelemetry
+  - NRDOT
+  - SQL Server
+  - Ansible
+metaDescription: Install and configure the NRDOT Collector for Microsoft SQL Server monitoring using the newrelic.newrelic_install Ansible role
+freshnessValidatedDate: never
+contentType: onboarding-intro
+audience: [human, ai]
+surface: [concept]
+integration: Microsoft-SQL-Server-with-NRDOT
+flow:
+
+  prev: /docs/opentelemetry/database/mssql/introduction
+
+  next: null
+---
+
+<Callout title="Preview">
+  We're still working on this feature, but we'd love for you to try it out!
+
+  This feature is currently provided as part of a preview pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
+</Callout>
+
+You can install and configure the NRDOT Collector for SQL Server monitoring using the `newrelic.newrelic_install` Ansible role. The role installs the collector, creates or authorizes the monitoring identity, and configures the collector in a single play.
+
+<Steps>
+
+<Step>
+
+## Prerequisites [#prerequisites]
+
+* New Relic account with a valid [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key), `NEW_RELIC_API_KEY`, and `NEW_RELIC_ACCOUNT_ID`.
+* SQL Server 2017 or later.
+* Ansible Core 2.13 or 2.14 (versions before 2.10 aren't supported), Python 3.10, and the `ansible.windows` and `ansible.utils` collections.
+* This integration is available as a part of New Relic public preview program. Check with your Organization Manager to opt in from the [Previews & Trials](https://one.newrelic.com/admin-portal/promotion-management/home) page.
+* For self-hosted SQL Server, SQL Server Authentication: a Windows, Ubuntu, or RHEL/CentOS collector host, with the `sa` login enabled and its password on hand.
+* For self-hosted SQL Server, Windows Domain Authentication or gMSA: a Windows collector host, and the Windows domain account (or gMSA) to grant permissions to.
+* For SQL Server on AWS RDS: a Windows, Ubuntu, or RHEL/CentOS collector host with network connectivity to the RDS endpoint (inbound access on the SQL Server port in the RDS security group), and the RDS master username and password.
+* For SQL Server on AWS RDS with Windows Domain Authentication or gMSA: a Windows collector host, and an RDS instance already joined to an AWS Managed Microsoft AD domain.
+* Network connectivity to [New Relic OTLP endpoint](/docs/opentelemetry/best-practices/opentelemetry-otlp) for your region.
+
+</Step>
+
+<Step>
+
+## Install the role [#ansible-install-role]
+
+```bash
+ansible-galaxy install newrelic.newrelic_install
+```
+
+Make sure the required collections are also installed:
+
+```bash
+ansible-galaxy collection install ansible.windows ansible.utils
+```
+
+</Step>
+
+<Step>
+
+## Configure the playbook [#ansible-configure]
+
+<CollapserGroup>
+
+<Collapser
+  id="ansible-host-sql"
+  title="Self-hosted - SQL Server Authentication"
+>
+
+Create a file named `playbook.yml` and copy the following content into it. Set `targets` to `mssql-otel` and replace the placeholder values with your own:
+
+```yaml
+- name: Install New Relic NRDOT for SQL Server
+  hosts: all
+  roles:
+    - role: newrelic.newrelic_install
+  vars:
+    targets:
+      - mssql-otel
+  environment:
+    NEW_RELIC_API_KEY: <API key>
+    NEW_RELIC_ACCOUNT_ID: <Account ID>
+    NEW_RELIC_REGION: <Region>
+    NR_CLI_MSSQL_CONFIG_PRESET: <1 for Standard, 2 for Full-feature, default 1>
+    NR_CLI_MSSQL_SERVER: <SQL Server host, default localhost>
+    NR_CLI_MSSQL_PORT: <SQL Server port, default 1433>
+    NR_CLI_MSSQL_SA_PASSWORD: <SQL Server 'sa' password>
+    NR_CLI_MSSQL_LOGIN_NAME: <monitoring username, default newrelic>
+```
+
+<Callout variant="tip">
+
+To enable debug logging, add `verbosity: "debug"` under `vars` in the playbook.
+
+</Callout>
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MSSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_SERVER`</td>
+      <td>SQL Server host.</td>
+      <td>`localhost`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_PORT`</td>
+      <td>SQL Server port.</td>
+      <td>`1433`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_SA_PASSWORD`</td>
+      <td>**Required.** SQL Server `sa` password, used once to create the monitoring login.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+<Collapser
+  id="ansible-host-winauth"
+  title="Self-hosted - Windows Authentication or gMSA"
+>
+
+This target is only supported on a Windows collector host. Create a file named `playbook.yml` and copy the following content into it. Set `targets` to `mssql-otel-winauth` and replace the placeholder values with your own:
+
+```yaml
+- name: Install New Relic NRDOT for SQL Server (Windows Auth)
+  hosts: all
+  roles:
+    - role: newrelic.newrelic_install
+  vars:
+    targets:
+      - mssql-otel-winauth
+  environment:
+    NEW_RELIC_API_KEY: <API key>
+    NEW_RELIC_ACCOUNT_ID: <Account ID>
+    NEW_RELIC_REGION: <Region>
+    NR_CLI_MSSQL_CONFIG_PRESET: <1 for Standard, 2 for Full-feature, default 1>
+    NR_CLI_MSSQL_AUTH_MODE: <1 for Windows Domain Auth, 2 for gMSA, default 1>
+    NR_CLI_MSSQL_SERVER: <SQL Server host, default localhost>
+    NR_CLI_MSSQL_PORT: <SQL Server port, default 1433>
+    NR_CLI_MSSQL_WIN_ACCOUNT: <Windows domain account, DOMAIN\username; Windows Domain Auth only>
+    NR_CLI_MSSQL_WIN_PASSWORD: <password for that account; Windows Domain Auth only>
+    NR_CLI_MSSQL_GMSA_ACCOUNT: <gMSA account, DOMAIN\gMSAName$; gMSA only>
+```
+
+<Callout variant="tip">
+
+To enable debug logging, add `verbosity: "debug"` under `vars` in the playbook.
+
+</Callout>
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MSSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_AUTH_MODE`</td>
+      <td>SQL Server authentication: `1` for Windows Domain Auth, `2` for gMSA.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_SERVER`</td>
+      <td>SQL Server host.</td>
+      <td>`localhost`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_PORT`</td>
+      <td>SQL Server port.</td>
+      <td>`1433`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_WIN_ACCOUNT` / `NR_CLI_MSSQL_WIN_PASSWORD`</td>
+      <td>**Required if `NR_CLI_MSSQL_AUTH_MODE` is `1`.** Windows domain account (`DOMAIN\username`) and password to grant permissions to and run the collector service as.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_GMSA_ACCOUNT`</td>
+      <td>**Required if `NR_CLI_MSSQL_AUTH_MODE` is `2`.** gMSA account (`DOMAIN\gMSAName$`) to grant permissions to.</td>
+      <td>None</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+<Collapser
+  id="ansible-rds-sql"
+  title="AWS RDS - SQL Server Authentication"
+>
+
+Create a file named `playbook.yml` and copy the following content into it. Set `targets` to `mssql-otel-rds` and replace the placeholder values with your own:
+
+```yaml
+- name: Install New Relic NRDOT for SQL Server on RDS
+  hosts: all
+  roles:
+    - role: newrelic.newrelic_install
+  vars:
+    targets:
+      - mssql-otel-rds
+  environment:
+    NEW_RELIC_API_KEY: <API key>
+    NEW_RELIC_ACCOUNT_ID: <Account ID>
+    NEW_RELIC_REGION: <Region>
+    NR_CLI_MSSQL_CONFIG_PRESET: <1 for Standard, 2 for Full-feature, default 1>
+    NR_CLI_MSSQL_SERVER: <RDS SQL Server endpoint>
+    NR_CLI_MSSQL_PORT: <SQL Server port, default 1433>
+    NR_CLI_MSSQL_MASTER_USER: <RDS master username>
+    NR_CLI_MSSQL_MASTER_PASSWORD: <RDS master password>
+    NR_CLI_MSSQL_LOGIN_NAME: <monitoring username, default newrelic>
+```
+
+<Callout variant="tip">
+
+To enable debug logging, add `verbosity: "debug"` under `vars` in the playbook.
+
+</Callout>
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MSSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_SERVER`</td>
+      <td>**Required.** RDS SQL Server endpoint.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_PORT`</td>
+      <td>SQL Server port.</td>
+      <td>`1433`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_MASTER_USER`</td>
+      <td>**Required.** RDS master username, used once to create the monitoring login.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_MASTER_PASSWORD`</td>
+      <td>**Required.** RDS master password.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+<Collapser
+  id="ansible-rds-winauth"
+  title="AWS RDS - Windows Domain Authentication or gMSA"
+>
+
+This target is only supported on a Windows collector host, and requires your RDS instance to already be joined to an AWS Managed Microsoft AD domain. Create a file named `playbook.yml` and copy the following content into it. Set `targets` to `mssql-otel-rds-winauth` and replace the placeholder values with your own:
+
+```yaml
+- name: Install New Relic NRDOT for SQL Server on RDS (Windows Auth)
+  hosts: all
+  roles:
+    - role: newrelic.newrelic_install
+  vars:
+    targets:
+      - mssql-otel-rds-winauth
+  environment:
+    NEW_RELIC_API_KEY: <API key>
+    NEW_RELIC_ACCOUNT_ID: <Account ID>
+    NEW_RELIC_REGION: <Region>
+    NR_CLI_MSSQL_CONFIG_PRESET: <1 for Standard, 2 for Full-feature, default 1>
+    NR_CLI_MSSQL_AUTH_MODE: <1 for Windows Domain Auth, 2 for gMSA, default 1>
+    NR_CLI_MSSQL_SERVER: <RDS SQL Server endpoint>
+    NR_CLI_MSSQL_PORT: <SQL Server port, default 1433>
+    NR_CLI_MSSQL_WIN_ACCOUNT: <Windows domain account, DOMAIN\username; Windows Domain Auth only>
+    NR_CLI_MSSQL_WIN_PASSWORD: <password for that account; Windows Domain Auth only>
+    NR_CLI_MSSQL_GMSA_ACCOUNT: <gMSA account, DOMAIN\gMSAName$; gMSA only>
+```
+
+<Callout variant="tip">
+
+To enable debug logging, add `verbosity: "debug"` under `vars` in the playbook.
+
+</Callout>
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MSSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_AUTH_MODE`</td>
+      <td>SQL Server authentication: `1` for Windows Domain Auth, `2` for gMSA.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_SERVER`</td>
+      <td>**Required.** RDS SQL Server endpoint.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_PORT`</td>
+      <td>SQL Server port.</td>
+      <td>`1433`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_WIN_ACCOUNT` / `NR_CLI_MSSQL_WIN_PASSWORD`</td>
+      <td>**Required if `NR_CLI_MSSQL_AUTH_MODE` is `1`.** Windows domain account (`DOMAIN\username`) and password to grant permissions to and run the collector service as.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_GMSA_ACCOUNT`</td>
+      <td>**Required if `NR_CLI_MSSQL_AUTH_MODE` is `2`.** gMSA account (`DOMAIN\gMSAName$`) to grant permissions to.</td>
+      <td>None</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+</CollapserGroup>
+
+<Callout variant="tip">
+  To securely manage sensitive information, such as database credentials, store them in [secret management](/docs/opentelemetry/database/capabilities/db-apm/#secret-management) tools, for example with [Ansible Vault](https://docs.ansible.com/ansible/latest/vault_guide/index.html).
+</Callout>
+
+</Step>
+
+<Step>
+
+## Run the playbook [#ansible-run]
+
+```bash
+ansible-playbook -i <inventory_file> <playbook_file>.yml
+```
+
+</Step>
+
+<Step>
+
+## Find and use your data [#find]
+
+Once your data is being collected, you can access comprehensive SQL Server database monitoring through the New Relic UI.
+
+To find your SQL Server database entity in New Relic:
+
+1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com) > All capabilities > Databases**</DNT>.
+2. From the **<DNT>Entity type</DNT>** dropdown, select <DNT>**MSSQL instance**</DNT>, then click <DNT>**Apply**</DNT>.
+3. Select your SQL Server database from the list of entities.
+
+    After setting up SQL Server monitoring with NRDOT, you can:
+
+    * [Create custom dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/) to visualize your database metrics
+    * [Set up alerts](/docs/alerts/create-alert/create-alert-condition/alert-conditions/) for critical database performance thresholds
+    * [Explore your data](/docs/query-your-data/explore-query-data/browse-data/introduction-data-explorer/) using New Relic query capabilities
+
+</Step>
+
+</Steps>
+
+## Related documentation [#related-docs]
+
+<DocTiles>
+  <DocTile title="Introduction to MSSQL monitoring with NRDOT" path="/docs/opentelemetry/database/mssql/introduction">Learn about all the available installation methods for MSSQL monitoring with New Relic.</DocTile>
+  <DocTile title="CLI install" path="/docs/opentelemetry/database/mssql/cli">Learn how to install and configure MSSQL monitoring with a single New Relic CLI command.</DocTile>
+  <DocTile title="Chef install" path="/docs/opentelemetry/database/mssql/chef">Learn how to install and configure MSSQL monitoring at scale with the newrelic-install Chef cookbook.</DocTile>
+  <DocTile title="Helm chart install" path="/docs/opentelemetry/database/mssql/helm">Learn how to install and configure MSSQL monitoring on Kubernetes with the mssql-otel Helm chart.</DocTile>
+  <DocTile title="Configuration reference" path="/docs/opentelemetry/database/mssql/config-reference">Learn about the full set of NRDOT Collector configuration options for MSSQL monitoring.</DocTile>
+  <DocTile title="Troubleshooting" path="/docs/opentelemetry/database/mssql/troubleshooting">Learn how to troubleshoot your MSSQL monitoring setup in New Relic.</DocTile>
+</DocTiles>

--- a/src/content/docs/opentelemetry/database/mssql/chef.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/chef.mdx
@@ -1,0 +1,415 @@
+---
+title: "Chef install for MSSQL monitoring with NRDOT"
+tags:
+  - OpenTelemetry
+  - NRDOT
+  - SQL Server
+  - Chef
+metaDescription: Install and configure the NRDOT Collector for Microsoft SQL Server monitoring using the newrelic-install Chef cookbook
+freshnessValidatedDate: never
+contentType: onboarding-intro
+audience: [human, ai]
+surface: [concept]
+integration: Microsoft-SQL-Server-with-NRDOT
+flow:
+
+  prev: /docs/opentelemetry/database/mssql/introduction
+
+  next: null
+---
+
+<Callout title="Preview">
+  We're still working on this feature, but we'd love for you to try it out!
+
+  This feature is currently provided as part of a preview pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
+</Callout>
+
+You can install and configure the NRDOT Collector for SQL Server monitoring using the `newrelic-install` Chef cookbook. The cookbook installs the collector, creates or authorizes the monitoring identity, and configures the collector when you run the `newrelic-install::default` recipe.
+
+<Steps>
+
+<Step>
+
+## Prerequisites [#prerequisites]
+
+* New Relic account with a valid [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key), `NEW_RELIC_API_KEY`, and `NEW_RELIC_ACCOUNT_ID`.
+* SQL Server 2017 or later.
+* Chef 15 or later.
+* This integration is available as a part of New Relic public preview program. Check with your Organization Manager to opt in from the [Previews & Trials](https://one.newrelic.com/admin-portal/promotion-management/home) page.
+* For self-hosted SQL Server, SQL Server Authentication: a Windows, Ubuntu, or RHEL/CentOS collector host, with the `sa` login enabled and its password on hand.
+* For self-hosted SQL Server, Windows Domain Authentication or gMSA: a Windows collector host, and the Windows domain account (or gMSA) to grant permissions to.
+* For SQL Server on AWS RDS: a Windows, Ubuntu, or RHEL/CentOS collector host with network connectivity to the RDS endpoint (inbound access on the SQL Server port in the RDS security group), and the RDS master username and password.
+* For SQL Server on AWS RDS with Windows Domain Authentication or gMSA: a Windows collector host, and an RDS instance already joined to an AWS Managed Microsoft AD domain.
+* Network connectivity to [New Relic OTLP endpoint](/docs/opentelemetry/best-practices/opentelemetry-otlp) for your region.
+
+</Step>
+
+<Step>
+
+## Download the Chef cookbook [#chef-download-cookbook]
+
+Download the `newrelic-install` [Chef cookbook](https://supermarket.chef.io/cookbooks/newrelic-install) from the Chef Supermarket to your chef-repo directory:
+
+```bash
+knife supermarket install newrelic-install
+```
+
+</Step>
+
+<Step>
+
+## Replace the default attributes [#chef-configure]
+
+Replace the default attributes in `attributes/default.rb` with your account details:
+
+<CollapserGroup>
+
+<Collapser
+  id="chef-host-sql"
+  title="Self-hosted - SQL Server Authentication"
+>
+
+```ruby
+default['newrelic_install']['NEW_RELIC_API_KEY']    = <API key>
+default['newrelic_install']['NEW_RELIC_ACCOUNT_ID'] = <Account ID>
+default['newrelic_install']['NEW_RELIC_REGION']     = <Region>
+default['newrelic_install']['targets'] = [
+  'nrdot-collector-mssql'
+]
+default['newrelic_install']['env']['NR_CLI_MSSQL_CONFIG_PRESET'] = <1 for Standard, 2 for Full-feature, default 1>
+default['newrelic_install']['env']['NR_CLI_MSSQL_SERVER']        = <SQL Server host, default localhost>
+default['newrelic_install']['env']['NR_CLI_MSSQL_PORT']          = <SQL Server port, default 1433>
+default['newrelic_install']['env']['NR_CLI_MSSQL_SA_PASSWORD']   = <SQL Server 'sa' password>
+default['newrelic_install']['env']['NR_CLI_MSSQL_LOGIN_NAME']    = <monitoring username, default newrelic>
+# See all available targets at: https://github.com/newrelic/chef-install
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute (under `env`)</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MSSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_SERVER`</td>
+      <td>SQL Server host.</td>
+      <td>`localhost`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_PORT`</td>
+      <td>SQL Server port.</td>
+      <td>`1433`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_SA_PASSWORD`</td>
+      <td>**Required.** SQL Server `sa` password, used once to create the monitoring login.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="tip">
+
+No default attribute values are shipped for these variables — set the ones relevant to your target explicitly via `default['newrelic_install']['env'][...]`.
+
+</Callout>
+
+</Collapser>
+
+<Collapser
+  id="chef-host-winauth"
+  title="Self-hosted - Windows Authentication or gMSA"
+>
+
+This target is only supported on a Windows collector host.
+
+```ruby
+default['newrelic_install']['NEW_RELIC_API_KEY']    = <API key>
+default['newrelic_install']['NEW_RELIC_ACCOUNT_ID'] = <Account ID>
+default['newrelic_install']['NEW_RELIC_REGION']     = <Region>
+default['newrelic_install']['targets'] = [
+  'nrdot-collector-mssql-winauth'
+]
+default['newrelic_install']['env']['NR_CLI_MSSQL_CONFIG_PRESET'] = <1 for Standard, 2 for Full-feature, default 1>
+default['newrelic_install']['env']['NR_CLI_MSSQL_AUTH_MODE']     = <1 for Windows Domain Auth, 2 for gMSA, default 1>
+default['newrelic_install']['env']['NR_CLI_MSSQL_SERVER']        = <SQL Server host, default localhost>
+default['newrelic_install']['env']['NR_CLI_MSSQL_PORT']          = <SQL Server port, default 1433>
+default['newrelic_install']['env']['NR_CLI_MSSQL_WIN_ACCOUNT']   = <Windows domain account, DOMAIN\username; Windows Domain Auth only>
+default['newrelic_install']['env']['NR_CLI_MSSQL_WIN_PASSWORD']  = <password for that account; Windows Domain Auth only>
+default['newrelic_install']['env']['NR_CLI_MSSQL_GMSA_ACCOUNT']  = <gMSA account, DOMAIN\gMSAName$; gMSA only>
+# See all available targets at: https://github.com/newrelic/chef-install
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute (under `env`)</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MSSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_AUTH_MODE`</td>
+      <td>SQL Server authentication: `1` for Windows Domain Auth, `2` for gMSA.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_SERVER`</td>
+      <td>SQL Server host.</td>
+      <td>`localhost`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_PORT`</td>
+      <td>SQL Server port.</td>
+      <td>`1433`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_WIN_ACCOUNT` / `NR_CLI_MSSQL_WIN_PASSWORD`</td>
+      <td>**Required if `NR_CLI_MSSQL_AUTH_MODE` is `1`.** Windows domain account (`DOMAIN\username`) and password to grant permissions to and run the collector service as.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_GMSA_ACCOUNT`</td>
+      <td>**Required if `NR_CLI_MSSQL_AUTH_MODE` is `2`.** gMSA account (`DOMAIN\gMSAName$`) to grant permissions to.</td>
+      <td>None</td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="tip">
+
+No default attribute values are shipped for these variables — set the ones relevant to your target explicitly via `default['newrelic_install']['env'][...]`.
+
+</Callout>
+
+</Collapser>
+
+<Collapser
+  id="chef-rds-sql"
+  title="AWS RDS - SQL Server Authentication"
+>
+
+```ruby
+default['newrelic_install']['NEW_RELIC_API_KEY']    = <API key>
+default['newrelic_install']['NEW_RELIC_ACCOUNT_ID'] = <Account ID>
+default['newrelic_install']['NEW_RELIC_REGION']     = <Region>
+default['newrelic_install']['targets'] = [
+  'nrdot-collector-mssql-rds'
+]
+default['newrelic_install']['env']['NR_CLI_MSSQL_CONFIG_PRESET']   = <1 for Standard, 2 for Full-feature, default 1>
+default['newrelic_install']['env']['NR_CLI_MSSQL_SERVER']          = <RDS SQL Server endpoint>
+default['newrelic_install']['env']['NR_CLI_MSSQL_PORT']            = <SQL Server port, default 1433>
+default['newrelic_install']['env']['NR_CLI_MSSQL_MASTER_USER']     = <RDS master username>
+default['newrelic_install']['env']['NR_CLI_MSSQL_MASTER_PASSWORD'] = <RDS master password>
+default['newrelic_install']['env']['NR_CLI_MSSQL_LOGIN_NAME']      = <monitoring username, default newrelic>
+# See all available targets at: https://github.com/newrelic/chef-install
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute (under `env`)</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MSSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_SERVER`</td>
+      <td>**Required.** RDS SQL Server endpoint.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_PORT`</td>
+      <td>SQL Server port.</td>
+      <td>`1433`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_MASTER_USER`</td>
+      <td>**Required.** RDS master username, used once to create the monitoring login.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_MASTER_PASSWORD`</td>
+      <td>**Required.** RDS master password.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="tip">
+
+No default attribute values are shipped for these variables — set the ones relevant to your target explicitly via `default['newrelic_install']['env'][...]`.
+
+</Callout>
+
+</Collapser>
+
+<Collapser
+  id="chef-rds-winauth"
+  title="AWS RDS - Windows Domain Authentication or gMSA"
+>
+
+This target is only supported on a Windows collector host, and requires your RDS instance to already be joined to an AWS Managed Microsoft AD domain.
+
+```ruby
+default['newrelic_install']['NEW_RELIC_API_KEY']    = <API key>
+default['newrelic_install']['NEW_RELIC_ACCOUNT_ID'] = <Account ID>
+default['newrelic_install']['NEW_RELIC_REGION']     = <Region>
+default['newrelic_install']['targets'] = [
+  'nrdot-collector-mssql-rds-winauth'
+]
+default['newrelic_install']['env']['NR_CLI_MSSQL_CONFIG_PRESET'] = <1 for Standard, 2 for Full-feature, default 1>
+default['newrelic_install']['env']['NR_CLI_MSSQL_AUTH_MODE']     = <1 for Windows Domain Auth, 2 for gMSA, default 1>
+default['newrelic_install']['env']['NR_CLI_MSSQL_SERVER']        = <RDS SQL Server endpoint>
+default['newrelic_install']['env']['NR_CLI_MSSQL_PORT']          = <SQL Server port, default 1433>
+default['newrelic_install']['env']['NR_CLI_MSSQL_WIN_ACCOUNT']   = <Windows domain account, DOMAIN\username; Windows Domain Auth only>
+default['newrelic_install']['env']['NR_CLI_MSSQL_WIN_PASSWORD']  = <password for that account; Windows Domain Auth only>
+default['newrelic_install']['env']['NR_CLI_MSSQL_GMSA_ACCOUNT']  = <gMSA account, DOMAIN\gMSAName$; gMSA only>
+# See all available targets at: https://github.com/newrelic/chef-install
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute (under `env`)</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MSSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_AUTH_MODE`</td>
+      <td>SQL Server authentication: `1` for Windows Domain Auth, `2` for gMSA.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_SERVER`</td>
+      <td>**Required.** RDS SQL Server endpoint.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_PORT`</td>
+      <td>SQL Server port.</td>
+      <td>`1433`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_WIN_ACCOUNT` / `NR_CLI_MSSQL_WIN_PASSWORD`</td>
+      <td>**Required if `NR_CLI_MSSQL_AUTH_MODE` is `1`.** Windows domain account (`DOMAIN\username`) and password to grant permissions to and run the collector service as.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_GMSA_ACCOUNT`</td>
+      <td>**Required if `NR_CLI_MSSQL_AUTH_MODE` is `2`.** gMSA account (`DOMAIN\gMSAName$`) to grant permissions to.</td>
+      <td>None</td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="tip">
+
+No default attribute values are shipped for these variables — set the ones relevant to your target explicitly via `default['newrelic_install']['env'][...]`.
+
+</Callout>
+
+</Collapser>
+
+</CollapserGroup>
+
+<Callout variant="tip">
+  To securely manage sensitive information, such as database credentials, store them in [secret management](/docs/opentelemetry/database/capabilities/db-apm/#secret-management) tools, for example with [Chef encrypted data bags](https://docs.chef.io/data_bags/#encrypt-a-data-bag-item).
+</Callout>
+
+</Step>
+
+<Step>
+
+## Upload the Chef cookbook [#chef-upload-cookbook]
+
+Upload the `newrelic-install` Chef cookbook to your Chef server:
+
+```bash
+knife cookbook upload newrelic-install
+```
+
+</Step>
+
+<Step>
+
+## Update the run list [#chef-run-list]
+
+Add the `newrelic-install` recipe to the run list of a node:
+
+```json
+"run_list": [
+  "recipe[newrelic-install]"
+]
+```
+
+</Step>
+
+<Step>
+
+## Find and use your data [#find]
+
+Once your data is being collected, you can access comprehensive SQL Server database monitoring through the New Relic UI.
+
+To find your SQL Server database entity in New Relic:
+
+1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com) > All capabilities > Databases**</DNT>.
+2. From the **<DNT>Entity type</DNT>** dropdown, select <DNT>**MSSQL instance**</DNT>, then click <DNT>**Apply**</DNT>.
+3. Select your SQL Server database from the list of entities.
+
+    After setting up SQL Server monitoring with NRDOT, you can:
+
+    * [Create custom dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/) to visualize your database metrics
+    * [Set up alerts](/docs/alerts/create-alert/create-alert-condition/alert-conditions/) for critical database performance thresholds
+    * [Explore your data](/docs/query-your-data/explore-query-data/browse-data/introduction-data-explorer/) using New Relic query capabilities
+
+</Step>
+
+</Steps>
+
+## Related documentation [#related-docs]
+
+<DocTiles>
+  <DocTile title="Introduction to MSSQL monitoring with NRDOT" path="/docs/opentelemetry/database/mssql/introduction">Learn about all the available installation methods for MSSQL monitoring with New Relic.</DocTile>
+  <DocTile title="Ansible install" path="/docs/opentelemetry/database/mssql/ansible">Learn how to install and configure MSSQL monitoring at scale with the newrelic.newrelic_install Ansible role.</DocTile>
+  <DocTile title="Helm chart install" path="/docs/opentelemetry/database/mssql/helm">Learn how to install and configure MSSQL monitoring on Kubernetes with the mssql-otel Helm chart.</DocTile>
+  <DocTile title="Configuration reference" path="/docs/opentelemetry/database/mssql/config-reference">Learn about the full set of NRDOT Collector configuration options for MSSQL monitoring.</DocTile>
+  <DocTile title="Troubleshooting" path="/docs/opentelemetry/database/mssql/troubleshooting">Learn how to troubleshoot your MSSQL monitoring setup in New Relic.</DocTile>
+</DocTiles>

--- a/src/content/docs/opentelemetry/database/mssql/cli.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/cli.mdx
@@ -1,0 +1,375 @@
+---
+title: "CLI install for MSSQL monitoring with NRDOT"
+tags:
+  - OpenTelemetry
+  - NRDOT
+  - SQL Server
+  - CLI
+metaDescription: Install and configure the NRDOT Collector for Microsoft SQL Server monitoring using the New Relic CLI
+freshnessValidatedDate: never
+contentType: onboarding-intro
+audience: [human, ai]
+surface: [concept]
+integration: Microsoft-SQL-Server-with-NRDOT
+flow:
+
+  prev: /docs/opentelemetry/database/mssql/introduction
+
+  next: null
+---
+
+<Callout title="Preview">
+  We're still working on this feature, but we'd love for you to try it out!
+
+  This feature is currently provided as part of a preview pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
+</Callout>
+
+You can install and configure the NRDOT Collector for SQL Server monitoring using the New Relic CLI. The CLI installs the collector, creates or authorizes the monitoring identity, and configures the collector in a single command.
+
+<Callout variant="tip">
+  To install this through the New Relic UI instead, go to <DNT> **[one.newrelic.com](https://one.newrelic.com) > Integrations & Agents > MSSQL (OpenTelemetry)** </DNT>. Follow the on-screen instructions to set up the integration.
+</Callout>
+
+<Steps>
+
+<Step>
+
+## Prerequisites [#prerequisites]
+
+* New Relic account with a valid [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key), `NEW_RELIC_API_KEY`, and `NEW_RELIC_ACCOUNT_ID`.
+* SQL Server 2017 or later.
+* This integration is available as a part of New Relic public preview program. Check with your Organization Manager to opt in from the [Previews & Trials](https://one.newrelic.com/admin-portal/promotion-management/home) page.
+* For self-hosted SQL Server, SQL Server Authentication: Linux or Windows collector host, with the `sa` login enabled and its password on hand.
+* For self-hosted SQL Server, Windows Authentication or gMSA: a Windows collector host, an Administrator PowerShell session, and the Windows account (or gMSA) to grant permissions to.
+* For SQL Server on AWS RDS: a Linux or Windows collector host with network connectivity to the RDS endpoint (inbound access on the SQL Server port in the RDS security group), and the RDS master username and password.
+* For SQL Server on AWS RDS with Windows Domain Authentication or gMSA: a Windows collector host, and an RDS instance already joined to an AWS Managed Microsoft AD domain.
+* On Linux: `curl` and `systemd`, plus the `sqlcmd` utility installed and reachable on `PATH` (or under `/opt/mssql-tools18/bin` or `/opt/mssql-tools/bin`).
+* On Windows: the `sqlcmd.exe` utility installed and reachable on `PATH`.
+* Network connectivity to [New Relic OTLP endpoint](/docs/opentelemetry/best-practices/opentelemetry-otlp) for your region.
+
+</Step>
+
+<Step>
+
+## Install and configure the NRDOT Collector [#cli-install]
+
+<CollapserGroup>
+
+<Collapser
+  id="cli-host-sql"
+  title="Self-hosted - SQL Server Authentication"
+>
+
+Before you run this command, have ready:
+
+* SQL Server host and port
+* The `sa` password (used once to create the monitoring login)
+* Monitoring username (leave the default `newrelic`, or choose your own)
+* Whether you want Standard or Full-feature metrics
+
+**Linux:**
+
+```bash
+curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && sudo NEW_RELIC_API_KEY=INSERT_YOUR_API_KEY NEW_RELIC_ACCOUNT_ID=INSERT_YOUR_ACCOUNT_ID NEW_RELIC_REGION=INSERT_YOUR_REGION /usr/local/bin/newrelic install -n nrdot-collector-mssql
+```
+
+**Windows** (run in an Administrator PowerShell session):
+
+```powershell
+[Net.ServicePointManager]::SecurityProtocol = 'tls12, tls'; $WebClient = New-Object System.Net.WebClient; $WebClient.DownloadFile("https://download.newrelic.com/install/newrelic-cli/scripts/install.ps1", "$env:TEMP\install.ps1"); & PowerShell.exe -ExecutionPolicy Bypass -File $env:TEMP\install.ps1; $env:NEW_RELIC_API_KEY='INSERT_YOUR_API_KEY'; $env:NEW_RELIC_ACCOUNT_ID='INSERT_YOUR_ACCOUNT_ID'; $env:NEW_RELIC_REGION='INSERT_YOUR_REGION'; & 'C:\Program Files\New Relic\New Relic CLI\newrelic.exe' install -n nrdot-collector-mssql
+```
+
+The CLI prompts interactively for the following variables. You can also set them ahead of time as environment variables to run non-interactively.
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MSSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_SERVER`</td>
+      <td>SQL Server host.</td>
+      <td>`localhost`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_PORT`</td>
+      <td>SQL Server port.</td>
+      <td>`1433`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_SA_PASSWORD`</td>
+      <td>**Required.** SQL Server `sa` password, used once to create the monitoring login.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+<Collapser
+  id="cli-host-winauth"
+  title="Self-hosted - Windows Authentication or gMSA"
+>
+
+This method is only supported on a Windows collector host.
+
+Before you run this command, have ready:
+
+* SQL Server host and port
+* Whether you're using a Windows account or a gMSA account
+* The Windows account (or gMSA account) to grant permissions to
+* Whether you want Standard or Full-feature metrics
+
+Run this in an Administrator PowerShell session:
+
+```powershell
+[Net.ServicePointManager]::SecurityProtocol = 'tls12, tls'; $WebClient = New-Object System.Net.WebClient; $WebClient.DownloadFile("https://download.newrelic.com/install/newrelic-cli/scripts/install.ps1", "$env:TEMP\install.ps1"); & PowerShell.exe -ExecutionPolicy Bypass -File $env:TEMP\install.ps1; $env:NEW_RELIC_API_KEY='INSERT_YOUR_API_KEY'; $env:NEW_RELIC_ACCOUNT_ID='INSERT_YOUR_ACCOUNT_ID'; $env:NEW_RELIC_REGION='INSERT_YOUR_REGION'; & 'C:\Program Files\New Relic\New Relic CLI\newrelic.exe' install -n nrdot-collector-mssql-winauth
+```
+
+The CLI prompts interactively for the following variables. You can also set them ahead of time as environment variables to run non-interactively.
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MSSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_AUTH_MODE`</td>
+      <td>SQL Server authentication: `1` for Windows Authentication, `2` for gMSA.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_SERVER`</td>
+      <td>SQL Server host.</td>
+      <td>`localhost`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_PORT`</td>
+      <td>SQL Server port.</td>
+      <td>`1433`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_WIN_ACCOUNT`</td>
+      <td>Windows account to grant permissions to, `DOMAIN\username`. Windows Authentication only; leave blank for gMSA.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_WIN_PASSWORD`</td>
+      <td>Password for that Windows account. Windows Authentication only; leave blank for gMSA.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_GMSA_ACCOUNT`</td>
+      <td>gMSA account, `DOMAIN\gMSAName$`. gMSA only; leave blank for Windows Authentication.</td>
+      <td>None</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+<Collapser
+  id="cli-rds-sql"
+  title="AWS RDS - SQL Server Authentication"
+>
+
+Before you run this command, have ready:
+
+* RDS SQL Server endpoint and port
+* RDS master username and password
+* Monitoring username (leave the default `newrelic`, or choose your own)
+* Whether you want Standard or Full-feature metrics
+
+**Linux:**
+
+```bash
+curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && sudo NEW_RELIC_API_KEY=INSERT_YOUR_API_KEY NEW_RELIC_ACCOUNT_ID=INSERT_YOUR_ACCOUNT_ID NEW_RELIC_REGION=INSERT_YOUR_REGION /usr/local/bin/newrelic install -n nrdot-collector-mssql-rds
+```
+
+**Windows** (run in an Administrator PowerShell session):
+
+```powershell
+[Net.ServicePointManager]::SecurityProtocol = 'tls12, tls'; $WebClient = New-Object System.Net.WebClient; $WebClient.DownloadFile("https://download.newrelic.com/install/newrelic-cli/scripts/install.ps1", "$env:TEMP\install.ps1"); & PowerShell.exe -ExecutionPolicy Bypass -File $env:TEMP\install.ps1; $env:NEW_RELIC_API_KEY='INSERT_YOUR_API_KEY'; $env:NEW_RELIC_ACCOUNT_ID='INSERT_YOUR_ACCOUNT_ID'; $env:NEW_RELIC_REGION='INSERT_YOUR_REGION'; & 'C:\Program Files\New Relic\New Relic CLI\newrelic.exe' install -n nrdot-collector-mssql-rds
+```
+
+The CLI prompts interactively for the following variables. You can also set them ahead of time as environment variables to run non-interactively.
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MSSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_SERVER`</td>
+      <td>**Required.** RDS SQL Server endpoint.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_PORT`</td>
+      <td>SQL Server port.</td>
+      <td>`1433`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_MASTER_USER`</td>
+      <td>**Required.** RDS master username, used once to create the monitoring login.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_MASTER_PASSWORD`</td>
+      <td>**Required.** RDS master user password.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+<Collapser
+  id="cli-rds-winauth"
+  title="AWS RDS - Windows Domain Authentication or gMSA"
+>
+
+This method is only supported on a Windows collector host, and requires your RDS instance to already be joined to an AWS Managed Microsoft AD domain.
+
+Before you run this command, have ready:
+
+* RDS SQL Server endpoint and port
+* Whether you're using a Windows domain account or a gMSA account
+* The domain account (or gMSA account) to grant permissions to
+* Whether you want Standard or Full-feature metrics
+
+Run this in an Administrator PowerShell session:
+
+```powershell
+[Net.ServicePointManager]::SecurityProtocol = 'tls12, tls'; $WebClient = New-Object System.Net.WebClient; $WebClient.DownloadFile("https://download.newrelic.com/install/newrelic-cli/scripts/install.ps1", "$env:TEMP\install.ps1"); & PowerShell.exe -ExecutionPolicy Bypass -File $env:TEMP\install.ps1; $env:NEW_RELIC_API_KEY='INSERT_YOUR_API_KEY'; $env:NEW_RELIC_ACCOUNT_ID='INSERT_YOUR_ACCOUNT_ID'; $env:NEW_RELIC_REGION='INSERT_YOUR_REGION'; & 'C:\Program Files\New Relic\New Relic CLI\newrelic.exe' install -n nrdot-collector-mssql-rds-winauth
+```
+
+The CLI prompts interactively for the following variables. You can also set them ahead of time as environment variables to run non-interactively.
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MSSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_AUTH_MODE`</td>
+      <td>SQL Server authentication: `1` for Windows Domain Authentication, `2` for gMSA.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_SERVER`</td>
+      <td>**Required.** RDS SQL Server endpoint.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_PORT`</td>
+      <td>SQL Server port.</td>
+      <td>`1433`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_WIN_ACCOUNT`</td>
+      <td>Windows domain account to grant permissions to, `DOMAIN\username`. Windows Domain Authentication only; leave blank for gMSA.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_WIN_PASSWORD`</td>
+      <td>Password for that domain account. Windows Domain Authentication only; leave blank for gMSA.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MSSQL_GMSA_ACCOUNT`</td>
+      <td>gMSA account, `DOMAIN\gMSAName$`. gMSA only; leave blank for Windows Domain Authentication.</td>
+      <td>None</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+</CollapserGroup>
+
+<Callout variant="tip">
+  To securely manage sensitive information, such as database credentials, store them in [secret management](/docs/opentelemetry/database/capabilities/db-apm/#secret-management) tools.
+</Callout>
+
+</Step>
+
+<Step>
+
+## Find and use your data [#find]
+
+Once your data is being collected, you can access comprehensive SQL Server database monitoring through the New Relic UI.
+
+To find your SQL Server database entity in New Relic:
+
+1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com) > All capabilities > Databases**</DNT>.
+2. From the **<DNT>Entity type</DNT>** dropdown, select <DNT>**MSSQL instance**</DNT>, then click <DNT>**Apply**</DNT>.
+3. Select your SQL Server database from the list of entities.
+
+    After setting up SQL Server monitoring with NRDOT, you can:
+
+    * [Create custom dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/) to visualize your database metrics
+    * [Set up alerts](/docs/alerts/create-alert/create-alert-condition/alert-conditions/) for critical database performance thresholds
+    * [Explore your data](/docs/query-your-data/explore-query-data/browse-data/introduction-data-explorer/) using New Relic query capabilities
+
+</Step>
+
+</Steps>
+
+## Related documentation [#related-docs]
+
+<DocTiles>
+  <DocTile title="Introduction to MSSQL monitoring with NRDOT" path="/docs/opentelemetry/database/mssql/introduction">Learn about all the available installation methods for MSSQL monitoring with New Relic.</DocTile>
+  <DocTile title="Ansible install" path="/docs/opentelemetry/database/mssql/ansible">Learn how to install and configure MSSQL monitoring at scale with the newrelic.newrelic_install Ansible role.</DocTile>
+  <DocTile title="Chef install" path="/docs/opentelemetry/database/mssql/chef">Learn how to install and configure MSSQL monitoring at scale with the newrelic-install Chef cookbook.</DocTile>
+  <DocTile title="Helm chart install" path="/docs/opentelemetry/database/mssql/helm">Learn how to install and configure MSSQL monitoring on Kubernetes with the mssql-otel Helm chart.</DocTile>
+  <DocTile title="Configuration reference" path="/docs/opentelemetry/database/mssql/config-reference">Learn about the full set of NRDOT Collector configuration options for MSSQL monitoring.</DocTile>
+  <DocTile title="Troubleshooting" path="/docs/opentelemetry/database/mssql/troubleshooting">Learn how to troubleshoot your MSSQL monitoring setup in New Relic.</DocTile>
+  <DocTile title="Metrics reference" path="/docs/opentelemetry/database/mssql/metrics-reference">Learn about the available metrics collected by the NRDOT Collector.</DocTile>
+</DocTiles>

--- a/src/content/docs/opentelemetry/database/mssql/helm.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/helm.mdx
@@ -1,0 +1,321 @@
+---
+title: "Helm chart install for MSSQL monitoring with NRDOT"
+tags:
+  - OpenTelemetry
+  - NRDOT
+  - SQL Server
+  - Kubernetes
+  - Helm
+metaDescription: Install and configure Microsoft SQL Server monitoring on Kubernetes using the mssql-otel Helm chart
+freshnessValidatedDate: never
+contentType: onboarding-intro
+audience: [human, ai]
+surface: [concept]
+integration: Microsoft-SQL-Server-with-NRDOT
+flow:
+
+  prev: /docs/opentelemetry/database/mssql/introduction
+
+  next: null
+---
+
+<Callout title="Preview">
+  We're still working on this feature, but we'd love for you to try it out!
+
+  This feature is currently provided as part of a preview pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
+</Callout>
+
+You can install and configure SQL Server monitoring on Kubernetes using the `mssql-otel` Helm chart. Depending on how you provide credentials, the chart can also run a setup job that creates the monitoring login for you.
+
+<Callout variant="important">
+  This chart only supports SQL Server Authentication (username/password) — it does not support Windows Authentication, Windows Domain Authentication, or gMSA. The collector always reaches SQL Server remotely over the network, whether it runs on Linux or Windows, self-hosted or on RDS, so SQL authentication works identically in every case. It also reports SQL Server metrics only — no host/infrastructure metrics — since the collector runs as a Kubernetes Deployment rather than on the SQL Server host itself.
+</Callout>
+
+<Steps>
+
+<Step>
+
+### Prerequisites [#helm-prerequisites]
+
+* Valid New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).
+* Helm 3.0 or later, and `kubectl` configured to access your Kubernetes cluster.
+* Network connectivity from your Kubernetes cluster to the SQL Server host (or RDS endpoint) and port:
+  * Self-hosted: a routed path to the SQL Server host (VPN, peering, or shared network), and the SQL Server-side firewall must allow the connection's source IP.
+  * AWS RDS: VPC peering, a transit gateway, or shared-VPC placement with the RDS instance, and the RDS security group must allow the SQL Server port (`1433` by default) from the cluster's egress source.
+* Either a monitoring login you've already created, or SQL Server admin credentials (a `sysadmin`-role login, such as `sa` or the RDS master user) so the chart's setup job can create one for you. See [Configure monitoring credentials](#helm-credentials) below.
+
+</Step>
+
+<Step>
+
+### Create the namespace [#helm-namespace]
+
+Create the namespace you'll install into. It must exist before you create any secrets in the next step, since `helm install --create-namespace` only creates the namespace during the final install step:
+
+```bash
+kubectl create namespace newrelic
+```
+
+<Callout variant="tip">
+
+  Set it as the default namespace for your current `kubectl` context so you don't need to pass `-n` on every command below:
+
+  ```bash
+  kubectl config set-context --current --namespace=newrelic
+  ```
+
+</Callout>
+
+</Step>
+
+<Step>
+
+### Configure monitoring credentials [#helm-credentials]
+
+Choose how the chart should get the SQL Server monitoring login's credentials:
+
+<CollapserGroup>
+
+<Collapser
+  id="helm-creds-inline"
+  title="Plain username and password"
+>
+
+With this method there's no setup job, so nothing here creates the monitoring login for you. This chart only supports SQL Server Authentication, so before installing it, create the monitoring login yourself using the SQL Server Authentication **Create monitoring user** step from [Linux self-hosted](/docs/opentelemetry/database/mssql/linux-hosted/#user), [Windows self-hosted](/docs/opentelemetry/database/mssql/windows-hosted/#user-sql), [Linux RDS](/docs/opentelemetry/database/mssql/linux-rds/#user), or [Windows RDS](/docs/opentelemetry/database/mssql/windows-rds/#user-sql), depending on your environment.
+
+You'll set the monitoring username and password directly in `values.yaml` in the next step.
+
+</Collapser>
+
+<Collapser
+  id="helm-creds-secret"
+  title="Secret-based credentials"
+>
+
+With this method, the chart's setup job creates the monitoring login for you using SQL Server admin credentials.
+
+1. Create a secret with the monitoring username and password. This is the identity the setup job creates and the collector connects with:
+
+    ```bash
+    kubectl create secret generic mssql-monitor-creds \
+      --from-literal=username=<MONITORING_USERNAME> \
+      --from-literal=password='<MONITORING_PASSWORD>' \
+      -n newrelic
+    ```
+
+2. The setup job only accepts admin credentials via a Kubernetes secret (no plaintext username/password in `values.yaml`). Since this credential can create logins and grant broad `VIEW` access, create it as its own secret. Use the `sa` login for self-hosted SQL Server, or the RDS master user for SQL Server on AWS RDS:
+
+    ```bash
+    kubectl create secret generic mssql-admin-creds \
+      --from-literal=username=<ADMIN_USERNAME> \
+      --from-literal=password='<ADMIN_PASSWORD>' \
+      -n newrelic
+    ```
+
+</Collapser>
+
+</CollapserGroup>
+
+</Step>
+
+<Step>
+
+### Configure the Helm values [#helm-configure]
+
+Set `mssql.topology` to match your environment:
+
+<table>
+  <thead>
+    <tr>
+      <th>Value</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`self-hosted`</td>
+      <td>Self-hosted SQL Server, reached over the network (Linux or Windows host).</td>
+    </tr>
+    <tr>
+      <td>`rds`</td>
+      <td>SQL Server on AWS RDS.</td>
+    </tr>
+  </tbody>
+</table>
+
+Use the `values.yaml` that matches the credential method you chose in the previous step:
+
+<CollapserGroup>
+
+<Collapser
+  id="helm-values-inline"
+  title="Plain username and password"
+>
+
+```yaml
+licenseKey: <YOUR_LICENSE_KEY>
+otlpEndpoint: https://otlp.nr-data.net:4318
+
+mssql:
+  topology: <self-hosted|rds>
+  server: <YOUR_DB_HOST>
+  port: <YOUR_DB_PORT>
+  username: <YOUR_MONITORING_USERNAME>
+  password: <YOUR_MONITORING_PASSWORD>
+
+# setupJob.sqlAdmin only ever accepts existingSecret (no
+# plaintext username/password), and since this credential
+# can create logins and grant broad VIEW access, the setup
+# job is only ever enabled for Secret-based credentials.
+# Create the monitoring login yourself before installing
+# the chart.
+setupJob:
+  enabled: false
+```
+
+</Collapser>
+
+<Collapser
+  id="helm-values-secret"
+  title="Secret-based credentials"
+>
+
+```yaml
+licenseKey: <YOUR_LICENSE_KEY>
+otlpEndpoint: https://otlp.nr-data.net:4318
+
+mssql:
+  topology: <self-hosted|rds>
+  server: <YOUR_DB_HOST>
+  port: <YOUR_DB_PORT>
+  existingSecret: mssql-monitor-creds
+
+setupJob:
+  enabled: true
+  image:
+    # -- sqlcmd image. No default: see the chart's README for why
+    # (mcr.microsoft.com/mssql-tools:latest is freely pullable but
+    # stale and unmaintained).
+    repository: ""
+    tag: ""
+    pullPolicy: IfNotPresent
+  sqlAdmin:
+    existingSecret: mssql-admin-creds
+```
+
+</Collapser>
+
+</CollapserGroup>
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`licenseKey`</td>
+      <td>Your New Relic license key.</td>
+    </tr>
+    <tr>
+      <td>`otlpEndpoint`</td>
+      <td>Your region's OTLP/HTTP endpoint, as a full URL with scheme: `https://otlp.nr-data.net:4318` (US) or `https://otlp.eu01.nr-data.net:4318` (EU). For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/).</td>
+    </tr>
+    <tr>
+      <td>`mssql.server` / `mssql.port`</td>
+      <td>Your SQL Server host (or RDS endpoint) and port, reachable from the cluster.</td>
+    </tr>
+    <tr>
+      <td>`mssql.tls.enabled` / `mssql.tls.trustServerCertificate`</td>
+      <td>Optional. Set `enabled: true` to encrypt the connection to SQL Server, and `trustServerCertificate: true` to skip certificate validation (useful for self-signed certs in test environments).</td>
+    </tr>
+    <tr>
+      <td>`setupJob.image.repository` / `setupJob.image.tag`</td>
+      <td>A `sqlcmd`-capable image used by the setup job. There's no default: Microsoft's freely pullable `mcr.microsoft.com/mssql-tools:latest` is dated 2017 and unmaintained, so confirm you're comfortable with its age (including unpatched CVEs) before using it, or build a current image yourself from Microsoft's `mssql-tools18` apt packages. Only required for secret-based credentials, where the setup job is enabled.</td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="tip">
+
+  See the chart's [values.yaml](https://github.com/newrelic/helm-charts/blob/master/charts/mssql-otel/values.yaml) for all available configuration options, including `mssql.collectionInterval`, `mssql.maxConcurrentQueries`, and the `additionalReceiverConfig` escape hatch.
+
+</Callout>
+
+</Step>
+
+<Step>
+
+### Install the Helm chart [#helm-install]
+
+1. Add the New Relic Helm repository:
+
+    ```bash
+    helm repo add newrelic https://helm-charts.newrelic.com
+    helm repo update
+    ```
+
+2. Install the chart using your `values.yaml` file:
+
+    ```bash
+    helm upgrade --install mssql-otel newrelic/mssql-otel \
+      -n newrelic \
+      --create-namespace \
+      -f values.yaml
+    ```
+
+</Step>
+
+<Step>
+
+### Verify the installation [#helm-verify]
+
+1. Check that the setup job completed (if enabled) and the collector pod is running:
+
+    ```bash
+    kubectl get jobs,pods -n newrelic --watch
+    ```
+
+2. Run this query in the [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder/) to confirm data is arriving:
+
+    ```sql
+    SELECT count(*) FROM Metric
+    WHERE metricName LIKE 'sqlserver.%'
+    AND instrumentation.provider = 'opentelemetry'
+    SINCE 10 minutes ago
+    ```
+
+</Step>
+
+<Step>
+
+## Find and use your data [#find]
+
+Once your data is being collected, you can access comprehensive SQL Server database monitoring through the New Relic UI.
+
+To find your SQL Server database entity in New Relic:
+
+1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com) > All capabilities > Databases**</DNT>.
+2. From the **<DNT>Entity type</DNT>** dropdown, select <DNT>**MSSQL instance**</DNT>, then click <DNT>**Apply**</DNT>.
+3. Select your SQL Server database from the list of entities.
+
+    After setting up SQL Server monitoring with NRDOT, you can:
+
+    * [Create custom dashboards](/docs/query-your-data/explore-query-data/dashboards/introduction-dashboards/) to visualize your database metrics
+    * [Set up alerts](/docs/alerts/create-alert/create-alert-condition/alert-conditions/) for critical database performance thresholds
+    * [Explore your data](/docs/query-your-data/explore-query-data/browse-data/introduction-data-explorer/) using New Relic query capabilities
+
+</Step>
+
+</Steps>
+
+## Related documentation [#related-docs]
+
+<DocTiles>
+  <DocTile title="Introduction to MSSQL monitoring with NRDOT" path="/docs/opentelemetry/database/mssql/introduction">Learn about all the available installation methods for MSSQL monitoring with New Relic.</DocTile>
+  <DocTile title="CLI install" path="/docs/opentelemetry/database/mssql/cli">Learn how to install and configure MSSQL monitoring with a single New Relic CLI command.</DocTile>
+  <DocTile title="Configuration reference" path="/docs/opentelemetry/database/mssql/config-reference">Learn about the full set of NRDOT Collector configuration options for MSSQL monitoring.</DocTile>
+  <DocTile title="Troubleshooting" path="/docs/opentelemetry/database/mssql/troubleshooting">Learn how to troubleshoot your MSSQL monitoring setup in New Relic.</DocTile>
+</DocTiles>

--- a/src/content/docs/opentelemetry/database/mssql/introduction.mdx
+++ b/src/content/docs/opentelemetry/database/mssql/introduction.mdx
@@ -25,6 +25,10 @@ flow:
     - /docs/opentelemetry/database/mssql/linux-hosted
     - /docs/opentelemetry/database/mssql/windows-rds
     - /docs/opentelemetry/database/mssql/linux-rds
+    - /docs/opentelemetry/database/mssql/cli
+    - /docs/opentelemetry/database/mssql/ansible
+    - /docs/opentelemetry/database/mssql/chef
+    - /docs/opentelemetry/database/mssql/helm
 ---
 
 <Callout title="Preview">
@@ -56,6 +60,10 @@ You can install NRDOT Collector for SQL Server monitoring in following ways:
 * AWS RDS environments: Cloud-managed SQL Server monitoring:
   * [Windows RDS monitoring](/docs/opentelemetry/database/mssql/windows-rds)
   * [Linux RDS monitoring](/docs/opentelemetry/database/mssql/linux-rds)
+* [New Relic CLI](/docs/opentelemetry/database/mssql/cli): Install and configure the collector with a single command, on self-hosted or AWS RDS SQL Server
+* [Ansible](/docs/opentelemetry/database/mssql/ansible): Install and configure the collector at scale using the `newrelic.newrelic_install` Ansible role
+* [Chef](/docs/opentelemetry/database/mssql/chef): Install and configure the collector at scale using the `newrelic-install` Chef cookbook
+* [Helm chart](/docs/opentelemetry/database/mssql/helm): Install and configure SQL Server monitoring on Kubernetes using the `mssql-otel` Helm chart
 
 ## Guided install [#ui-install]
 
@@ -88,7 +96,11 @@ For supported detailed prerequisites, refer to the dedicated prerequisites secti
 
 Choose your installation path based on your infrastructure:
 
-- **Guided install**: To install via New Relic UI, go to <DNT> **[one.newrelic.com](https://one.newrelic.com) > Integrations & Agents > MSSQL (OpenTelemetry)** </DNT>. Follow the on-screen instructions to set up the integration. This page covers the CLI install path only.
+- **Guided install**: To install via New Relic UI, go to <DNT> **[one.newrelic.com](https://one.newrelic.com) > Integrations & Agents > MSSQL (OpenTelemetry)** </DNT>. Follow the on-screen instructions to set up the integration.
+- **[New Relic CLI](/docs/opentelemetry/database/mssql/cli)**: Install and configure the collector with a single command
+- **[Ansible](/docs/opentelemetry/database/mssql/ansible)**: Install and configure the collector at scale using the `newrelic.newrelic_install` Ansible role
+- **[Chef](/docs/opentelemetry/database/mssql/chef)**: Install and configure the collector at scale using the `newrelic-install` Chef cookbook
+- **[Helm chart](/docs/opentelemetry/database/mssql/helm)**: Install and configure SQL Server monitoring on Kubernetes using the `mssql-otel` Helm chart
 - **Self-hosted environments**: Manual installation on your own infrastructure
   - [Windows self-hosted](/docs/opentelemetry/database/mssql/windows-hosted)
   - [Linux self-hosted](/docs/opentelemetry/database/mssql/linux-hosted)
@@ -154,5 +166,9 @@ To correlate your application performance with database operations, you can set 
 <DocTiles>
   <DocTile title="Linux instrumentation for self-hosted environments" path="/docs/opentelemetry/database/mssql/linux-hosted">Learn how to set up MSSQL monitoring in self-hosted Linux environments with New Relic.</DocTile>
   <DocTile title="Windows instrumentation for self-hosted environments" path="/docs/opentelemetry/database/mssql/windows-hosted">Learn how to set up MSSQL monitoring in self-hosted Windows environments with New Relic.</DocTile>
+  <DocTile title="CLI install" path="/docs/opentelemetry/database/mssql/cli">Learn how to install and configure MSSQL monitoring with a single New Relic CLI command.</DocTile>
+  <DocTile title="Ansible install" path="/docs/opentelemetry/database/mssql/ansible">Learn how to install and configure MSSQL monitoring at scale with the newrelic.newrelic_install Ansible role.</DocTile>
+  <DocTile title="Chef install" path="/docs/opentelemetry/database/mssql/chef">Learn how to install and configure MSSQL monitoring at scale with the newrelic-install Chef cookbook.</DocTile>
+  <DocTile title="Helm chart install" path="/docs/opentelemetry/database/mssql/helm">Learn how to install and configure MSSQL monitoring on Kubernetes with the mssql-otel Helm chart.</DocTile>
   <DocTile title="Metrics reference" path="/docs/opentelemetry/database/mssql/metrics-reference">Learn about the available metrics collected by the NRDOT Collector.</DocTile>
 </DocTiles>

--- a/src/content/docs/opentelemetry/database/mysql/ansible.mdx
+++ b/src/content/docs/opentelemetry/database/mysql/ansible.mdx
@@ -1,0 +1,259 @@
+---
+title: "Ansible install for MySQL monitoring with NRDOT"
+tags:
+  - OpenTelemetry
+  - NRDOT
+  - MySQL
+  - MariaDB
+  - Ansible
+metaDescription: Install and configure the NRDOT Collector for MySQL monitoring using the newrelic.newrelic_install Ansible role
+freshnessValidatedDate: never
+---
+
+<Callout title="Preview">
+  We're still working on this feature, but we'd love for you to try it out!
+
+  This feature is currently provided as part of a preview pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
+</Callout>
+
+You can install and configure the NRDOT Collector for MySQL monitoring using the `newrelic.newrelic_install` Ansible role. The role installs the collector, creates the monitoring user, and configures the collector in a single play.
+
+<Steps>
+
+<Step>
+
+## Prerequisites [#prerequisites]
+
+* New Relic account with a valid [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key), `NEW_RELIC_API_KEY`, and `NEW_RELIC_ACCOUNT_ID`.
+* MySQL 5.7 or later.
+* Ansible Core 2.13 or 2.14 (versions before 2.10 aren't supported), Python 3.10, and the `ansible.windows` and `ansible.utils` collections.
+* A Linux collector host running Debian/Ubuntu or RHEL/CentOS.
+* This integration is available as a part of New Relic public preview program. Check with your Organization Manager to opt in from the [Previews & Trials](https://one.newrelic.com/admin-portal/promotion-management/home) page.
+* For self-hosted MySQL: administrative access to your MySQL server (the `root` account or equivalent), using password-based authentication.
+* For MySQL or Aurora on AWS RDS: network connectivity from the collector host to the RDS endpoint, and the RDS master username and password.
+* Network connectivity to [New Relic OTLP endpoint](/docs/opentelemetry/best-practices/opentelemetry-otlp) for your region.
+
+For detailed requirements, refer to [Compatibility and prerequisites](/docs/opentelemetry/database/mysql/compatibility).
+
+</Step>
+
+<Step>
+
+## Install the role [#ansible-install-role]
+
+```bash
+ansible-galaxy install newrelic.newrelic_install
+```
+
+Make sure the required collections are also installed:
+
+```bash
+ansible-galaxy collection install ansible.windows ansible.utils
+```
+
+</Step>
+
+<Step>
+
+## Configure the playbook [#ansible-configure]
+
+<CollapserGroup>
+
+<Collapser
+  id="ansible-host"
+  title="Self-hosted MySQL"
+>
+
+Create a file named `playbook.yml` and copy the following content into it. Set `targets` to `mysql-otel` and replace the placeholder values with your own:
+
+```yaml
+- name: Install New Relic NRDOT for MySQL
+  hosts: all
+  roles:
+    - role: newrelic.newrelic_install
+  vars:
+    targets:
+      - mysql-otel
+  environment:
+    NEW_RELIC_API_KEY: <API key>
+    NEW_RELIC_ACCOUNT_ID: <Account ID>
+    NEW_RELIC_REGION: <Region>
+    NR_CLI_MYSQL_CONFIG_PRESET: <1 for Standard, 2 for Full-feature, default 1>
+    NR_CLI_MYSQL_SERVER: <MySQL host, default localhost>
+    NR_CLI_MYSQL_PORT: <MySQL port, default 3306>
+    NR_CLI_MYSQL_ROOT_PASSWORD: <MySQL root password>
+    NR_CLI_MYSQL_LOGIN_NAME: <monitoring username, default newrelic>
+```
+
+<Callout variant="important">
+  The role connects to MySQL over TCP using a password, so the `root` account must use password-based authentication. On some Debian/Ubuntu installs, `root`@`localhost` defaults to the `auth_socket` plugin (no password, local-socket only), which won't work here. Switch it before running the playbook:
+
+  ```bash
+  mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '<password>';"
+  ```
+</Callout>
+
+<Callout variant="tip">
+
+To enable debug logging, add `verbosity: "debug"` under `vars` in the playbook.
+
+</Callout>
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MYSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_SERVER`</td>
+      <td>MySQL host.</td>
+      <td>`localhost`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_PORT`</td>
+      <td>MySQL port.</td>
+      <td>`3306`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_ROOT_PASSWORD`</td>
+      <td>**Required.** MySQL `root` password, used once to create the monitoring user.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+<Collapser
+  id="ansible-rds"
+  title="MySQL or Aurora on AWS RDS"
+>
+
+Create a file named `playbook.yml` and copy the following content into it. Set `targets` to `mysql-otel-rds` and replace the placeholder values with your own:
+
+```yaml
+- name: Install New Relic NRDOT for MySQL on RDS
+  hosts: all
+  roles:
+    - role: newrelic.newrelic_install
+  vars:
+    targets:
+      - mysql-otel-rds
+  environment:
+    NEW_RELIC_API_KEY: <API key>
+    NEW_RELIC_ACCOUNT_ID: <Account ID>
+    NEW_RELIC_REGION: <Region>
+    NR_CLI_MYSQL_CONFIG_PRESET: <1 for Standard, 2 for Full-feature, default 1>
+    NR_CLI_MYSQL_SERVER: <RDS MySQL or Aurora endpoint>
+    NR_CLI_MYSQL_PORT: <MySQL port, default 3306>
+    NR_CLI_MYSQL_MASTER_USER: <RDS master username>
+    NR_CLI_MYSQL_MASTER_PASSWORD: <RDS master password>
+    NR_CLI_MYSQL_LOGIN_NAME: <monitoring username, default newrelic>
+```
+
+<Callout variant="tip">
+
+To enable debug logging, add `verbosity: "debug"` under `vars` in the playbook.
+
+</Callout>
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MYSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_SERVER`</td>
+      <td>**Required.** RDS MySQL or Aurora endpoint. Unlike the self-hosted target, there's no default.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_PORT`</td>
+      <td>MySQL port.</td>
+      <td>`3306`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_MASTER_USER`</td>
+      <td>**Required.** RDS master username, used once to create the monitoring user.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_MASTER_PASSWORD`</td>
+      <td>**Required.** RDS master password.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+</CollapserGroup>
+
+<Callout variant="tip">
+  To securely manage sensitive information, such as database credentials, store them in [secret management](/docs/opentelemetry/database/capabilities/db-apm/#secret-management) tools, for example with [Ansible Vault](https://docs.ansible.com/ansible/latest/vault_guide/index.html).
+</Callout>
+
+</Step>
+
+<Step>
+
+## Run the playbook [#ansible-run]
+
+```bash
+ansible-playbook -i <inventory_file> <playbook_file>.yml
+```
+
+</Step>
+
+<Step>
+
+## Find and use your data [#find]
+
+Once your data is being collected, you can access comprehensive MySQL database monitoring through the New Relic UI.
+
+To find your MySQL database entity in New Relic:
+
+1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com) > All capabilities > Databases**</DNT>.
+2. From the **<DNT>Entity type</DNT>** dropdown, select <DNT>**MySQL instance**</DNT>, then click <DNT>**Apply**</DNT>.
+3. Select your MySQL database from the list of entities.
+
+</Step>
+
+</Steps>
+
+## Related documentation [#related]
+
+<DocTiles>
+  <DocTile title="Introduction to MySQL monitoring with NRDOT" path="/docs/opentelemetry/database/mysql/introduction">Learn about all the available installation methods for MySQL monitoring with New Relic.</DocTile>
+  <DocTile title="CLI install" path="/docs/opentelemetry/database/mysql/cli">Learn how to install and configure MySQL monitoring with a single New Relic CLI command.</DocTile>
+  <DocTile title="Chef install" path="/docs/opentelemetry/database/mysql/chef">Learn how to install and configure MySQL monitoring at scale with the newrelic-install Chef cookbook.</DocTile>
+  <DocTile title="Helm chart install" path="/docs/opentelemetry/database/mysql/helm">Learn how to install and configure MySQL monitoring on Kubernetes with the mysql-otel Helm chart.</DocTile>
+</DocTiles>

--- a/src/content/docs/opentelemetry/database/mysql/chef.mdx
+++ b/src/content/docs/opentelemetry/database/mysql/chef.mdx
@@ -1,0 +1,267 @@
+---
+title: "Chef install for MySQL monitoring with NRDOT"
+tags:
+  - OpenTelemetry
+  - NRDOT
+  - MySQL
+  - MariaDB
+  - Chef
+metaDescription: Install and configure the NRDOT Collector for MySQL monitoring using the newrelic-install Chef cookbook
+freshnessValidatedDate: never
+---
+
+<Callout title="Preview">
+  We're still working on this feature, but we'd love for you to try it out!
+
+  This feature is currently provided as part of a preview pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
+</Callout>
+
+You can install and configure the NRDOT Collector for MySQL monitoring using the `newrelic-install` Chef cookbook. The cookbook installs the collector, creates the monitoring user, and configures the collector when you run the `newrelic-install::default` recipe.
+
+<Steps>
+
+<Step>
+
+## Prerequisites [#prerequisites]
+
+* New Relic account with a valid [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key), `NEW_RELIC_API_KEY`, and `NEW_RELIC_ACCOUNT_ID`.
+* MySQL 5.7 or later.
+* Chef 15 or later.
+* A Linux collector host running Debian/Ubuntu or RHEL/CentOS.
+* This integration is available as a part of New Relic public preview program. Check with your Organization Manager to opt in from the [Previews & Trials](https://one.newrelic.com/admin-portal/promotion-management/home) page.
+* For self-hosted MySQL: administrative access to your MySQL server (the `root` account or equivalent), using password-based authentication.
+* For MySQL or Aurora on AWS RDS: network connectivity from the collector host to the RDS endpoint, and the RDS master username and password.
+* Network connectivity to [New Relic OTLP endpoint](/docs/opentelemetry/best-practices/opentelemetry-otlp) for your region.
+
+For detailed requirements, refer to [Compatibility and prerequisites](/docs/opentelemetry/database/mysql/compatibility).
+
+</Step>
+
+<Step>
+
+## Download the Chef cookbook [#chef-download-cookbook]
+
+Download the `newrelic-install` [Chef cookbook](https://supermarket.chef.io/cookbooks/newrelic-install) from the Chef Supermarket to your chef-repo directory:
+
+```bash
+knife supermarket install newrelic-install
+```
+
+</Step>
+
+<Step>
+
+## Replace the default attributes [#chef-configure]
+
+Replace the default attributes in `attributes/default.rb` with your account details:
+
+<CollapserGroup>
+
+<Collapser
+  id="chef-host"
+  title="Self-hosted MySQL"
+>
+
+```ruby
+default['newrelic_install']['NEW_RELIC_API_KEY']    = <API key>
+default['newrelic_install']['NEW_RELIC_ACCOUNT_ID'] = <Account ID>
+default['newrelic_install']['NEW_RELIC_REGION']     = <Region>
+default['newrelic_install']['targets'] = [
+  'nrdot-collector-mysql'
+]
+default['newrelic_install']['env']['NR_CLI_MYSQL_CONFIG_PRESET'] = <1 for Standard, 2 for Full-feature, default 1>
+default['newrelic_install']['env']['NR_CLI_MYSQL_SERVER']        = <MySQL host, default localhost>
+default['newrelic_install']['env']['NR_CLI_MYSQL_PORT']          = <MySQL port, default 3306>
+default['newrelic_install']['env']['NR_CLI_MYSQL_ROOT_PASSWORD'] = <MySQL root password>
+default['newrelic_install']['env']['NR_CLI_MYSQL_LOGIN_NAME']    = <monitoring username, default newrelic>
+# See all available targets at: https://github.com/newrelic/chef-install
+```
+
+<Callout variant="important">
+  The cookbook connects to MySQL over TCP using a password, so the `root` account must use password-based authentication. On some Debian/Ubuntu installs, `root`@`localhost` defaults to the `auth_socket` plugin (no password, local-socket only), which won't work here. Switch it before running the recipe:
+
+  ```bash
+  mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '<password>';"
+  ```
+</Callout>
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute (under `env`)</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MYSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_SERVER`</td>
+      <td>MySQL host.</td>
+      <td>`localhost`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_PORT`</td>
+      <td>MySQL port.</td>
+      <td>`3306`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_ROOT_PASSWORD`</td>
+      <td>**Required.** MySQL `root` password, used once to create the monitoring user.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="tip">
+
+No default attribute values are shipped for these variables — set the ones relevant to your target explicitly via `default['newrelic_install']['env'][...]`.
+
+</Callout>
+
+</Collapser>
+
+<Collapser
+  id="chef-rds"
+  title="MySQL or Aurora on AWS RDS"
+>
+
+```ruby
+default['newrelic_install']['NEW_RELIC_API_KEY']    = <API key>
+default['newrelic_install']['NEW_RELIC_ACCOUNT_ID'] = <Account ID>
+default['newrelic_install']['NEW_RELIC_REGION']     = <Region>
+default['newrelic_install']['targets'] = [
+  'nrdot-collector-mysql-rds'
+]
+default['newrelic_install']['env']['NR_CLI_MYSQL_CONFIG_PRESET']   = <1 for Standard, 2 for Full-feature, default 1>
+default['newrelic_install']['env']['NR_CLI_MYSQL_SERVER']          = <RDS MySQL or Aurora endpoint>
+default['newrelic_install']['env']['NR_CLI_MYSQL_PORT']            = <MySQL port, default 3306>
+default['newrelic_install']['env']['NR_CLI_MYSQL_MASTER_USER']     = <RDS master username>
+default['newrelic_install']['env']['NR_CLI_MYSQL_MASTER_PASSWORD'] = <RDS master password>
+default['newrelic_install']['env']['NR_CLI_MYSQL_LOGIN_NAME']      = <monitoring username, default newrelic>
+default['newrelic_install']['env']['NR_CLI_MYSQL_TLS_CA_FILE']     = <path to CA certificate file, blank to skip CA validation>
+# See all available targets at: https://github.com/newrelic/chef-install
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute (under `env`)</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MYSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_SERVER`</td>
+      <td>**Required.** RDS MySQL or Aurora endpoint.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_PORT`</td>
+      <td>MySQL port.</td>
+      <td>`3306`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_MASTER_USER`</td>
+      <td>**Required.** RDS master username, used once to create the monitoring user.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_MASTER_PASSWORD`</td>
+      <td>**Required.** RDS master password.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_TLS_CA_FILE`</td>
+      <td>Path to a CA certificate file for validating the server's TLS certificate. Leave blank to skip CA validation. Required if your RDS instance enforces **Require SSL/TLS**.</td>
+      <td>None</td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="tip">
+
+No default attribute values are shipped for these variables — set the ones relevant to your target explicitly via `default['newrelic_install']['env'][...]`.
+
+</Callout>
+
+</Collapser>
+
+</CollapserGroup>
+
+<Callout variant="tip">
+  To securely manage sensitive information, such as database credentials, store them in [secret management](/docs/opentelemetry/database/capabilities/db-apm/#secret-management) tools, for example with [Chef encrypted data bags](https://docs.chef.io/data_bags/#encrypt-a-data-bag-item).
+</Callout>
+
+</Step>
+
+<Step>
+
+## Upload the Chef cookbook [#chef-upload-cookbook]
+
+Upload the `newrelic-install` Chef cookbook to your Chef server:
+
+```bash
+knife cookbook upload newrelic-install
+```
+
+</Step>
+
+<Step>
+
+## Update the run list [#chef-run-list]
+
+Add the `newrelic-install` recipe to the run list of a node:
+
+```json
+"run_list": [
+  "recipe[newrelic-install]"
+]
+```
+
+</Step>
+
+<Step>
+
+## Find and use your data [#find]
+
+Once your data is being collected, you can access comprehensive MySQL database monitoring through the New Relic UI.
+
+To find your MySQL database entity in New Relic:
+
+1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com) > All capabilities > Databases**</DNT>.
+2. From the **<DNT>Entity type</DNT>** dropdown, select <DNT>**MySQL instance**</DNT>, then click <DNT>**Apply**</DNT>.
+3. Select your MySQL database from the list of entities.
+
+</Step>
+
+</Steps>
+
+## Related documentation [#related]
+
+<DocTiles>
+  <DocTile title="Introduction to MySQL monitoring with NRDOT" path="/docs/opentelemetry/database/mysql/introduction">Learn about all the available installation methods for MySQL monitoring with New Relic.</DocTile>
+  <DocTile title="CLI install" path="/docs/opentelemetry/database/mysql/cli">Learn how to install and configure MySQL monitoring with a single New Relic CLI command.</DocTile>
+  <DocTile title="Ansible install" path="/docs/opentelemetry/database/mysql/ansible">Learn how to install and configure MySQL monitoring at scale with the newrelic.newrelic_install Ansible role.</DocTile>
+  <DocTile title="Helm chart install" path="/docs/opentelemetry/database/mysql/helm">Learn how to install and configure MySQL monitoring on Kubernetes with the mysql-otel Helm chart.</DocTile>
+</DocTiles>

--- a/src/content/docs/opentelemetry/database/mysql/cli.mdx
+++ b/src/content/docs/opentelemetry/database/mysql/cli.mdx
@@ -1,0 +1,227 @@
+---
+title: "CLI install for MySQL monitoring with NRDOT"
+tags:
+  - OpenTelemetry
+  - NRDOT
+  - MySQL
+  - MariaDB
+  - CLI
+metaDescription: Install and configure the NRDOT Collector for MySQL monitoring using the New Relic CLI
+freshnessValidatedDate: never
+---
+
+<Callout title="Preview">
+  We're still working on this feature, but we'd love for you to try it out!
+
+  This feature is currently provided as part of a preview pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
+</Callout>
+
+You can install and configure the NRDOT Collector for MySQL monitoring using the New Relic CLI. The CLI installs the collector, creates the monitoring user, and configures the collector in a single command.
+
+<Callout variant="tip">
+  To install this through the New Relic UI instead, refer to [guided install](/docs/opentelemetry/database/mysql/guided).
+</Callout>
+
+<Steps>
+
+<Step>
+
+## Prerequisites [#prerequisites]
+
+* New Relic account with a valid [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key), `NEW_RELIC_API_KEY`, and `NEW_RELIC_ACCOUNT_ID`.
+* MySQL 5.7 or later.
+* A Linux collector host running Debian/Ubuntu or RHEL/CentOS, with `curl` and `systemd` installed, and the `mysql` client available.
+* This integration is available as a part of New Relic public preview program. Check with your Organization Manager to opt in from the [Previews & Trials](https://one.newrelic.com/admin-portal/promotion-management/home) page.
+* For self-hosted MySQL: administrative access to your MySQL server (the `root` account or equivalent).
+* For MySQL or Aurora on AWS RDS: network connectivity from the collector host to the RDS endpoint (inbound access on the MySQL port in the RDS security group), and the RDS master username and password.
+* Network connectivity to [New Relic OTLP endpoint](/docs/opentelemetry/best-practices/opentelemetry-otlp) for your region.
+
+For detailed requirements, refer to [Compatibility and prerequisites](/docs/opentelemetry/database/mysql/compatibility).
+
+</Step>
+
+<Step>
+
+## Install and configure the NRDOT Collector [#cli-install]
+
+<CollapserGroup>
+
+<Collapser
+  id="cli-host"
+  title="Self-hosted MySQL"
+>
+
+Before you run this command, have ready:
+
+* MySQL host and port
+* The `root` password (used once to create the monitoring user)
+* Monitoring username (leave the default `newrelic`, or choose your own)
+* Whether you want Standard or Full-feature metrics
+
+```bash
+curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && sudo NEW_RELIC_API_KEY=INSERT_YOUR_API_KEY NEW_RELIC_ACCOUNT_ID=INSERT_YOUR_ACCOUNT_ID NEW_RELIC_REGION=INSERT_YOUR_REGION /usr/local/bin/newrelic install -n nrdot-collector-mysql
+```
+
+<Callout variant="important">
+  This installer connects to MySQL over TCP using a password, so the `root` account must use password-based authentication. On some Debian/Ubuntu installs, `root`@`localhost` defaults to the `auth_socket` plugin (no password, local-socket only), which won't work here. Switch it first by running this locally as root:
+
+  ```bash
+  mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '<password>';"
+  ```
+
+  If that fails with `Access denied`, the `mysql-server` package also creates a `debian-sys-maint` account with known admin credentials in `/etc/mysql/debian.cnf` — use it instead:
+
+  ```bash
+  mysql --defaults-file=/etc/mysql/debian.cnf -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '<password>';"
+  ```
+</Callout>
+
+The CLI prompts interactively for the following variables. You can also set them ahead of time as environment variables to run non-interactively.
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MYSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_SERVER`</td>
+      <td>MySQL host.</td>
+      <td>`localhost`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_PORT`</td>
+      <td>MySQL port.</td>
+      <td>`3306`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_ROOT_PASSWORD`</td>
+      <td>**Required.** MySQL `root` password, used once to create the monitoring user.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+<Collapser
+  id="cli-rds"
+  title="MySQL or Aurora on AWS RDS"
+>
+
+Before you run this command, have ready:
+
+* RDS MySQL or Aurora endpoint and port
+* RDS master username and password
+* Monitoring username (leave the default `newrelic`, or choose your own)
+* Whether you want Standard or Full-feature metrics
+
+```bash
+curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && sudo NEW_RELIC_API_KEY=INSERT_YOUR_API_KEY NEW_RELIC_ACCOUNT_ID=INSERT_YOUR_ACCOUNT_ID NEW_RELIC_REGION=INSERT_YOUR_REGION /usr/local/bin/newrelic install -n nrdot-collector-mysql-rds
+```
+
+The CLI prompts interactively for the following variables. You can also set them ahead of time as environment variables to run non-interactively.
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_MYSQL_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_SERVER`</td>
+      <td>**Required.** RDS MySQL or Aurora endpoint.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_PORT`</td>
+      <td>MySQL port.</td>
+      <td>`3306`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_MASTER_USER`</td>
+      <td>**Required.** RDS master username, used once to create the monitoring user.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_MASTER_PASSWORD`</td>
+      <td>**Required.** RDS master user password.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_MYSQL_TLS_CA_FILE`</td>
+      <td>Path to a CA certificate file for validating the server's TLS certificate. Leave blank to skip CA validation. Required if your RDS instance enforces **Require SSL/TLS** — point it at Amazon's RDS CA bundle.</td>
+      <td>None</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+</CollapserGroup>
+
+<Callout variant="tip">
+  To securely manage sensitive information, such as database credentials, store them in [secret management](/docs/opentelemetry/database/capabilities/db-apm/#secret-management) tools.
+</Callout>
+
+</Step>
+
+<Step>
+
+## Find and use your data [#find]
+
+Once your data is being collected, you can access comprehensive MySQL database monitoring through the New Relic UI.
+
+To find your MySQL database entity in New Relic:
+
+1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com) > All capabilities > Databases**</DNT>.
+2. From the **<DNT>Entity type</DNT>** dropdown, select <DNT>**MySQL instance**</DNT>, then click <DNT>**Apply**</DNT>.
+3. Select your MySQL database from the list of entities.
+
+To confirm data is arriving, run this query in the [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder/):
+
+```sql
+SELECT count(*) FROM Metric
+WHERE metricName LIKE 'mysql.%'
+AND instrumentation.provider = 'opentelemetry'
+SINCE 10 minutes ago
+```
+
+</Step>
+
+</Steps>
+
+## Related documentation [#related]
+
+<DocTiles>
+  <DocTile title="Introduction to MySQL monitoring with NRDOT" path="/docs/opentelemetry/database/mysql/introduction">Learn about all the available installation methods for MySQL monitoring with New Relic.</DocTile>
+  <DocTile title="Ansible install" path="/docs/opentelemetry/database/mysql/ansible">Learn how to install and configure MySQL monitoring at scale with the newrelic.newrelic_install Ansible role.</DocTile>
+  <DocTile title="Chef install" path="/docs/opentelemetry/database/mysql/chef">Learn how to install and configure MySQL monitoring at scale with the newrelic-install Chef cookbook.</DocTile>
+  <DocTile title="Helm chart install" path="/docs/opentelemetry/database/mysql/helm">Learn how to install and configure MySQL monitoring on Kubernetes with the mysql-otel Helm chart.</DocTile>
+</DocTiles>

--- a/src/content/docs/opentelemetry/database/mysql/helm.mdx
+++ b/src/content/docs/opentelemetry/database/mysql/helm.mdx
@@ -1,0 +1,318 @@
+---
+title: "Helm chart install for MySQL monitoring with NRDOT"
+tags:
+  - OpenTelemetry
+  - NRDOT
+  - MySQL
+  - MariaDB
+  - Kubernetes
+  - Helm
+metaDescription: Install and configure MySQL monitoring on Kubernetes using the mysql-otel Helm chart
+freshnessValidatedDate: never
+---
+
+<Callout title="Preview">
+  We're still working on this feature, but we'd love for you to try it out!
+
+  This feature is currently provided as part of a preview pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
+</Callout>
+
+You can install and configure MySQL monitoring on Kubernetes using the `mysql-otel` Helm chart. Depending on how you provide credentials, the chart can also run a setup job that creates the monitoring user for you.
+
+<Callout variant="important">
+  The chart deploys the collector as a Kubernetes Deployment that reaches MySQL remotely over the network. As a result it always connects over TCP (Unix-socket monitoring isn't supported), and it reports MySQL metrics only — no host or infrastructure metrics for the machine MySQL runs on. It also monitors one MySQL instance per release, so install the chart once per database.
+</Callout>
+
+<Steps>
+
+<Step>
+
+### Prerequisites [#helm-prerequisites]
+
+* Valid New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).
+* MySQL 5.7 or later.
+* Helm 3.0 or later, and `kubectl` configured to access your Kubernetes cluster.
+* Network connectivity from your Kubernetes cluster to the MySQL host (or RDS endpoint) and port:
+  * Self-hosted: a routed path to the MySQL host (VPN, peering, or shared network), DNS resolution if it's a hostname, and the MySQL-side firewall must allow the connection's actual source IP (which may be a NAT gateway, not the pod IP itself).
+  * AWS RDS: VPC peering, a transit gateway, or shared-VPC placement with the RDS instance, and the RDS security group must allow the MySQL port (`3306` by default) from the cluster's egress source.
+* Either a monitoring user you've already created, or MySQL admin credentials so the chart's setup job can create one for you. See [Configure monitoring credentials](#helm-credentials) below.
+
+</Step>
+
+<Step>
+
+### Create the namespace [#helm-namespace]
+
+Create the namespace you'll install into. It must exist before you create any secrets in the next step, since `helm install --create-namespace` only creates the namespace during the final install step:
+
+```bash
+kubectl create namespace newrelic
+```
+
+<Callout variant="tip">
+
+  Set it as the default namespace for your current `kubectl` context so you don't need to pass `-n` on every command below:
+
+  ```bash
+  kubectl config set-context --current --namespace=newrelic
+  ```
+
+</Callout>
+
+</Step>
+
+<Step>
+
+### Configure monitoring credentials [#helm-credentials]
+
+Choose how the chart should get the MySQL monitoring user's credentials:
+
+<CollapserGroup>
+
+<Collapser
+  id="helm-creds-inline"
+  title="Plain username and password"
+>
+
+With this method there's no setup job, so nothing here creates the monitoring user for you. Before installing the chart, create it yourself using the **Configure database user** step from [self-hosted MySQL](/docs/opentelemetry/database/mysql/hosted/#user) or [MySQL on RDS](/docs/opentelemetry/database/mysql/rds/#user), or run the equivalent SQL as an admin user:
+
+```sql
+CREATE USER IF NOT EXISTS 'newrelic'@'%' IDENTIFIED BY '<password>';
+GRANT SELECT ON performance_schema.* TO 'newrelic'@'%';
+FLUSH PRIVILEGES;
+```
+
+You'll set the monitoring username and password directly in `values.yaml` in the next step.
+
+</Collapser>
+
+<Collapser
+  id="helm-creds-secret"
+  title="Secret-based credentials"
+>
+
+With this method, the chart's setup job creates the monitoring user for you using MySQL admin credentials.
+
+1. Create a secret with the monitoring username and password. This is the identity the setup job creates and the collector connects with:
+
+    ```bash
+    kubectl create secret generic mysql-monitor-creds \
+      --from-literal=username=<MONITORING_USERNAME> \
+      --from-literal=password='<MONITORING_PASSWORD>' \
+      -n newrelic
+    ```
+
+2. The setup job only accepts admin credentials via a Kubernetes secret (no plaintext username/password in `values.yaml`). Since this credential can run `CREATE USER` and grant broad `performance_schema` access, create it as its own secret. Use the `root` account for self-hosted MySQL, or the RDS master user for MySQL on AWS RDS:
+
+    ```bash
+    kubectl create secret generic mysql-admin-creds \
+      --from-literal=username=<ADMIN_USERNAME> \
+      --from-literal=password='<ADMIN_PASSWORD>' \
+      -n newrelic
+    ```
+
+</Collapser>
+
+</CollapserGroup>
+
+</Step>
+
+<Step>
+
+### Configure the Helm values [#helm-configure]
+
+Set `mysql.topology` to match your environment:
+
+<table>
+  <thead>
+    <tr>
+      <th>Value</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`self-hosted`</td>
+      <td>Self-hosted MySQL, reached over the network.</td>
+    </tr>
+    <tr>
+      <td>`rds`</td>
+      <td>MySQL or Aurora on AWS RDS.</td>
+    </tr>
+  </tbody>
+</table>
+
+Use the `values.yaml` that matches the credential method you chose in the previous step:
+
+<CollapserGroup>
+
+<Collapser
+  id="helm-values-inline"
+  title="Plain username and password"
+>
+
+```yaml
+licenseKey: <YOUR_LICENSE_KEY>
+otlpEndpoint: otlp.nr-data.net:4317
+
+mysql:
+  topology: <self-hosted|rds>
+  server: <YOUR_DB_HOST>
+  port: <YOUR_DB_PORT>
+  username: <YOUR_MONITORING_USERNAME>
+  password: <YOUR_MONITORING_PASSWORD>
+
+# setupJob.mysqlAdmin only ever accepts existingSecret (no
+# plaintext username/password), and since this credential
+# can create users and grant broad performance_schema
+# access, the setup job is only ever enabled for
+# Secret-based credentials. Create the monitoring user
+# yourself before installing the chart.
+setupJob:
+  enabled: false
+```
+
+</Collapser>
+
+<Collapser
+  id="helm-values-secret"
+  title="Secret-based credentials"
+>
+
+```yaml
+licenseKey: <YOUR_LICENSE_KEY>
+otlpEndpoint: otlp.nr-data.net:4317
+
+mysql:
+  topology: <self-hosted|rds>
+  server: <YOUR_DB_HOST>
+  port: <YOUR_DB_PORT>
+  existingSecret: mysql-monitor-creds
+
+setupJob:
+  enabled: true
+  mysqlAdmin:
+    existingSecret: mysql-admin-creds
+  # -- Also grants UPDATE on performance_schema.setup_consumers,
+  # needed for wait-time data. Optional.
+  enableWaitTimeMetrics: false
+```
+
+</Collapser>
+
+</CollapserGroup>
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`licenseKey`</td>
+      <td>Your New Relic license key.</td>
+    </tr>
+    <tr>
+      <td>`otlpEndpoint`</td>
+      <td>Your region's OTLP/gRPC endpoint, as a bare `host:port` with **no scheme**: `otlp.nr-data.net:4317` (US) or `otlp.eu01.nr-data.net:4317` (EU). For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/).</td>
+    </tr>
+    <tr>
+      <td>`mysql.server` / `mysql.port`</td>
+      <td>Your MySQL host (or RDS endpoint) and port, reachable from the cluster.</td>
+    </tr>
+    <tr>
+      <td>`mysql.database`</td>
+      <td>Optional. Restrict monitoring to one database. Leave empty to monitor all databases.</td>
+    </tr>
+    <tr>
+      <td>`mysql.tls.insecure` / `insecureSkipVerify` / `caFile`</td>
+      <td>Optional. `insecure: false` (the default) requires an encrypted connection, `insecureSkipVerify: true` skips certificate validation, and `caFile` points at a CA bundle mounted into the collector container. An **Amazon RDS instance with Require SSL/TLS enforcement needs `caFile` set to Amazon's RDS CA bundle** — the chart deliberately ships no default, since a hardcoded bundle risks going stale as Amazon rotates CAs.</td>
+    </tr>
+    <tr>
+      <td>`setupJob.image.repository` / `setupJob.image.tag`</td>
+      <td>The `mysql` CLI image used by the setup job. Defaults to the official, actively maintained `mysql:8.4`, so enabling the setup job needs no extra image flags. Override only if you need a different version.</td>
+    </tr>
+    <tr>
+      <td>`setupJob.enableWaitTimeMetrics`</td>
+      <td>Optional. Also grants `UPDATE` on `performance_schema.setup_consumers`, which is needed for wait-time data.</td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="tip">
+
+  See the chart's [values.yaml](https://github.com/newrelic/helm-charts/blob/master/charts/mysql-otel/values.yaml) for all available configuration options, including `mysql.collectionInterval`, `mysql.explainMode`, the `statementEvents`/`querySampleCollection`/`topQueryCollection` blocks, and the `additionalReceiverConfig` escape hatch.
+
+</Callout>
+
+</Step>
+
+<Step>
+
+### Install the Helm chart [#helm-install]
+
+1. Add the New Relic Helm repository:
+
+    ```bash
+    helm repo add newrelic https://helm-charts.newrelic.com
+    helm repo update
+    ```
+
+2. Install the chart using your `values.yaml` file:
+
+    ```bash
+    helm upgrade --install mysql-otel newrelic/mysql-otel \
+      -n newrelic \
+      --create-namespace \
+      -f values.yaml
+    ```
+
+</Step>
+
+<Step>
+
+### Verify the installation [#helm-verify]
+
+1. Check that the setup job completed (if enabled) and the collector pod is running:
+
+    ```bash
+    kubectl get jobs,pods -n newrelic --watch
+    ```
+
+2. Run this query in the [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder/) to confirm data is arriving:
+
+    ```sql
+    SELECT count(*) FROM Metric
+    WHERE metricName LIKE 'mysql.%'
+    AND instrumentation.provider = 'opentelemetry'
+    SINCE 10 minutes ago
+    ```
+
+</Step>
+
+<Step>
+
+## Find and use your data [#find]
+
+Once your data is being collected, you can access comprehensive MySQL database monitoring through the New Relic UI.
+
+To find your MySQL database entity in New Relic:
+
+1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com) > All capabilities > Databases**</DNT>.
+2. From the **<DNT>Entity type</DNT>** dropdown, select <DNT>**MySQL instance**</DNT>, then click <DNT>**Apply**</DNT>.
+3. Select your MySQL database from the list of entities.
+
+</Step>
+
+</Steps>
+
+## Related documentation [#related]
+
+<DocTiles>
+  <DocTile title="Introduction to MySQL monitoring with NRDOT" path="/docs/opentelemetry/database/mysql/introduction">Learn about all the available installation methods for MySQL monitoring with New Relic.</DocTile>
+  <DocTile title="CLI install" path="/docs/opentelemetry/database/mysql/cli">Learn how to install and configure MySQL monitoring with a single New Relic CLI command.</DocTile>
+  <DocTile title="Ansible install" path="/docs/opentelemetry/database/mysql/ansible">Learn how to install and configure MySQL monitoring at scale with the newrelic.newrelic_install Ansible role.</DocTile>
+  <DocTile title="Chef install" path="/docs/opentelemetry/database/mysql/chef">Learn how to install and configure MySQL monitoring at scale with the newrelic-install Chef cookbook.</DocTile>
+</DocTiles>

--- a/src/content/docs/opentelemetry/database/mysql/introduction.mdx
+++ b/src/content/docs/opentelemetry/database/mysql/introduction.mdx
@@ -45,8 +45,14 @@ For detailed requirements, see [Compatibility and prerequisites](/docs/opentelem
 
 Choose your installation path based on your infrastructure:
 
-* [Self-hosted MySQL](/docs/opentelemetry/database/mysql/hosted)
-* [RDS MySQL monitoring](/docs/opentelemetry/database/mysql/rds)
+* **Manual install**: Set up the collector yourself on your own infrastructure
+  * [Self-hosted MySQL](/docs/opentelemetry/database/mysql/hosted)
+  * [RDS MySQL monitoring](/docs/opentelemetry/database/mysql/rds)
+* **[Guided install](/docs/opentelemetry/database/mysql/guided)**: Follow step-by-step instructions in the New Relic UI
+* **[New Relic CLI](/docs/opentelemetry/database/mysql/cli)**: Install and configure the collector with a single command
+* **[Ansible](/docs/opentelemetry/database/mysql/ansible)**: Install and configure the collector at scale using the `newrelic.newrelic_install` Ansible role
+* **[Chef](/docs/opentelemetry/database/mysql/chef)**: Install and configure the collector at scale using the `newrelic-install` Chef cookbook
+* **[Helm chart](/docs/opentelemetry/database/mysql/helm)**: Install and configure MySQL monitoring on Kubernetes using the `mysql-otel` Helm chart
 
 </Step>
 
@@ -79,5 +85,9 @@ To correlate your application performance with database operations, you can set 
 <DocTiles>
   <DocTile title="Instrumentation in self-hosted environments" path="/docs/opentelemetry/database/mysql/hosted">Learn how to set up MySQL monitoring in self-hosted environments with New Relic.</DocTile>
   <DocTile title="Instrumentation in RDS environments" path="/docs/opentelemetry/database/mysql/rds">Learn how to set up MySQL monitoring in RDS environments with New Relic.</DocTile>
+  <DocTile title="CLI install" path="/docs/opentelemetry/database/mysql/cli">Learn how to install and configure MySQL monitoring with a single New Relic CLI command.</DocTile>
+  <DocTile title="Ansible install" path="/docs/opentelemetry/database/mysql/ansible">Learn how to install and configure MySQL monitoring at scale with the newrelic.newrelic_install Ansible role.</DocTile>
+  <DocTile title="Chef install" path="/docs/opentelemetry/database/mysql/chef">Learn how to install and configure MySQL monitoring at scale with the newrelic-install Chef cookbook.</DocTile>
+  <DocTile title="Helm chart install" path="/docs/opentelemetry/database/mysql/helm">Learn how to install and configure MySQL monitoring on Kubernetes with the mysql-otel Helm chart.</DocTile>
   <DocTile title="Metrics reference" path="/docs/opentelemetry/database/mysql/metrics-reference">Learn about the available metrics collected by the NRDOT Collector.</DocTile>
 </DocTiles>

--- a/src/content/docs/opentelemetry/database/otel-oracledb.mdx
+++ b/src/content/docs/opentelemetry/database/otel-oracledb.mdx
@@ -57,6 +57,18 @@ The NRDOT Collector collects both infrastructure and database related telemetry 
         <TabsBarItem id="guided">
             Guided install
         </TabsBarItem>
+        <TabsBarItem id="cli">
+            CLI
+        </TabsBarItem>
+        <TabsBarItem id="ansible">
+            Ansible
+        </TabsBarItem>
+        <TabsBarItem id="chef">
+            Chef
+        </TabsBarItem>
+        <TabsBarItem id="helm">
+            Helm chart
+        </TabsBarItem>
         <TabsBarItem id="host">
             For on-host
         </TabsBarItem>
@@ -128,7 +140,946 @@ To find your Oracle Database entity in New Relic:
   
   
   </TabsPageItem>
-  
+
+  <TabsPageItem id="cli">
+
+You can install and configure the NRDOT Collector for Oracle Database monitoring using the New Relic CLI. The CLI installs the collector, creates the monitoring database user, and configures the collector in a single command.
+
+<Steps>
+
+<Step>
+
+### Prerequisites [#cli-prerequisites]
+
+* Valid New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key), `NEW_RELIC_API_KEY`, and `NEW_RELIC_ACCOUNT_ID`.
+* Oracle Database 19c or later.
+* For self-hosted Oracle: Oracle Linux 7, 8, or 9, with `curl` and `systemd` installed, and SSH access (with agent forwarding) to the Oracle Database host where the SSH user can run `sudo su - oracle` without a password prompt.
+* For Oracle on AWS RDS: a collector host running Debian/Ubuntu or CentOS/RHEL/OEL, with `curl` and `systemd` installed, and network connectivity from the collector host to the RDS Oracle endpoint.
+
+</Step>
+
+<Step>
+
+### Install and configure the NRDOT Collector [#cli-install]
+
+<CollapserGroup>
+
+<Collapser
+  id="cli-host"
+  title="Self-hosted Oracle Database"
+>
+
+Before you run this command, have ready:
+
+* Container type (CDB for all PDBs, or a single PDB name)
+* Oracle Database host and listener port
+* SSH user used to create the monitoring user
+* Monitoring username and password (leave the password blank to auto-generate one)
+* CDB or PDB service name for the collector connection
+* Whether you want database-only or host + database metrics
+
+Run:
+
+```bash
+curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && sudo NEW_RELIC_API_KEY=INSERT_YOUR_API_KEY NEW_RELIC_ACCOUNT_ID=INSERT_YOUR_ACCOUNT_ID NEW_RELIC_REGION=INSERT_YOUR_REGION /usr/local/bin/newrelic install -n nrdot-collector-oracle
+```
+
+The CLI prompts interactively for the following variables. You can also set them ahead of time as environment variables to run non-interactively.
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_ORACLE_HOST`</td>
+      <td>Oracle Database host.</td>
+      <td>`localhost`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_PORT`</td>
+      <td>Oracle listener port.</td>
+      <td>`1521`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_SSH_USER`</td>
+      <td>SSH user for the Oracle Database host, used once to create the monitoring user and grant privileges via OS-authenticated SYSDBA access.</td>
+      <td>`opc`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_CONTAINER_TYPE`</td>
+      <td>Oracle container type: `1` for CDB (monitor all PDBs) or `2` for a single PDB.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_PDB_NAME`</td>
+      <td>PDB name. Required only when `NR_CLI_ORACLE_CONTAINER_TYPE` is `2`.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_LOGIN_NAME`</td>
+      <td>Monitoring username (created as `c##&lt;name&gt;` in CDB mode).</td>
+      <td>`newrelic`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_LOGIN_PASSWORD`</td>
+      <td>**Required.** Password for the monitoring login. Leave blank in an interactive install to auto-generate a random password.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_SERVICE_NAME`</td>
+      <td>**Required.** CDB or PDB service name for the collector connection.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_CONFIG_PRESET`</td>
+      <td>`1` for database metrics only, `2` for host and database metrics.</td>
+      <td>`1`</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+<Collapser
+  id="cli-rds"
+  title="Oracle Database on AWS RDS"
+>
+
+Before you run this command, have ready:
+
+* RDS Oracle endpoint and listener port
+* RDS master username and password
+* Monitoring username and password (leave the password blank to auto-generate one)
+* RDS DB service name for the collector connection
+* Whether you want database-only or host + database metrics
+
+Run:
+
+```bash
+curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && sudo NEW_RELIC_API_KEY=INSERT_YOUR_API_KEY NEW_RELIC_ACCOUNT_ID=INSERT_YOUR_ACCOUNT_ID NEW_RELIC_REGION=INSERT_YOUR_REGION /usr/local/bin/newrelic install -n nrdot-collector-oracle-rds
+```
+
+The CLI prompts interactively for the following variables. You can also set them ahead of time as environment variables to run non-interactively.
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_ORACLE_HOST`</td>
+      <td>**Required.** The RDS Oracle endpoint.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_PORT`</td>
+      <td>Oracle listener port.</td>
+      <td>`1521`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_ADMIN_USER`</td>
+      <td>**Required.** RDS master username, used once to create the monitoring user and grant privileges.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_ADMIN_PASSWORD`</td>
+      <td>**Required.** RDS master password.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_LOGIN_PASSWORD`</td>
+      <td>**Required.** Password for the monitoring login.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_SERVICE_NAME`</td>
+      <td>**Required.** The RDS DB service name for the collector connection.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_CONFIG_PRESET`</td>
+      <td>`1` for database metrics only, `2` for host and database metrics.</td>
+      <td>`1`</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+</CollapserGroup>
+
+</Step>
+
+</Steps>
+
+To find your Oracle Database entity in New Relic, see [Find and use your data](/docs/opentelemetry/database/otel-oracledb/#find-use-data).
+
+  </TabsPageItem>
+
+  <TabsPageItem id="ansible">
+
+You can install and configure the NRDOT Collector for Oracle Database monitoring using the `newrelic.newrelic_install` Ansible role. The role installs the collector, creates the monitoring database user, and configures the collector in a single play.
+
+<Steps>
+
+<Step>
+
+### Prerequisites [#ansible-prerequisites]
+
+* Valid New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key), `NEW_RELIC_API_KEY`, and `NEW_RELIC_ACCOUNT_ID`.
+* Oracle Database 19c or later.
+* Ansible Core 2.13 or 2.14 (versions before 2.10 aren't supported), Python 3.10, and the `ansible.windows` and `ansible.utils` collections.
+* For self-hosted Oracle: Oracle Linux 7, 8, or 9, with SSH access (with agent forwarding) to the Oracle Database host where the SSH user can run `sudo su - oracle` without a password prompt.
+* For Oracle on AWS RDS: a collector host running Debian/Ubuntu or CentOS/RHEL/OEL.
+
+</Step>
+
+<Step>
+
+### Install the role [#ansible-install-role]
+
+```bash
+ansible-galaxy install newrelic.newrelic_install
+```
+
+</Step>
+
+<Step>
+
+### Configure the playbook [#ansible-configure]
+
+<CollapserGroup>
+
+<Collapser
+  id="ansible-host"
+  title="Self-hosted Oracle Database"
+>
+
+Create a file named `playbook.yml` and copy the following content into it. Set `targets` to `oracle-otel` and replace the placeholder values with your own:
+
+```yaml
+- name: Install New Relic NRDOT for Oracle Database
+  hosts: all
+  roles:
+    - role: newrelic.newrelic_install
+  vars:
+    targets:
+      - oracle-otel
+  environment:
+    NEW_RELIC_API_KEY: <API key>
+    NEW_RELIC_ACCOUNT_ID: <Account ID>
+    NEW_RELIC_REGION: <Region>
+    NR_CLI_ORACLE_HOST: <Oracle Database host, default localhost>
+    NR_CLI_ORACLE_PORT: <Oracle listener port, default 1521>
+    NR_CLI_ORACLE_SSH_USER: <SSH user, default opc>
+    NR_CLI_ORACLE_CONTAINER_TYPE: <1 for CDB, 2 for PDB, default 1>
+    NR_CLI_ORACLE_PDB_NAME: <PDB name, only if container type is 2>
+    NR_CLI_ORACLE_LOGIN_NAME: <monitoring username, default newrelic>
+    NR_CLI_ORACLE_LOGIN_PASSWORD: <monitoring user password>
+    NR_CLI_ORACLE_SERVICE_NAME: <CDB or PDB service name>
+    NR_CLI_ORACLE_CONFIG_PRESET: <1 for database only, 2 for host and database, default 1>
+```
+
+<Callout variant="tip">
+
+To enable debug logging, add `verbosity: "debug"` under `vars` in the playbook.
+
+</Callout>
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_ORACLE_HOST`</td>
+      <td>Oracle Database host.</td>
+      <td>`localhost`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_PORT`</td>
+      <td>Oracle listener port.</td>
+      <td>`1521`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_SSH_USER`</td>
+      <td>SSH user for the Oracle Database host, used once to create the monitoring user and grant privileges via OS-authenticated SYSDBA access.</td>
+      <td>`opc`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_CONTAINER_TYPE`</td>
+      <td>Oracle container type: `1` for CDB (monitor all PDBs) or `2` for a single PDB.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_PDB_NAME`</td>
+      <td>PDB name. Required only when `NR_CLI_ORACLE_CONTAINER_TYPE` is `2`.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_LOGIN_NAME`</td>
+      <td>Monitoring username (created as `c##&lt;name&gt;` in CDB mode).</td>
+      <td>`newrelic`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_LOGIN_PASSWORD`</td>
+      <td>**Required.** The role installs non-interactively, so a real value must be supplied.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_SERVICE_NAME`</td>
+      <td>**Required.** CDB or PDB service name for the collector connection.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_CONFIG_PRESET`</td>
+      <td>`1` for database metrics only, `2` for host and database metrics.</td>
+      <td>`1`</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+<Collapser
+  id="ansible-rds"
+  title="Oracle Database on AWS RDS"
+>
+
+Create a file named `playbook.yml` and copy the following content into it. Set `targets` to `oracle-otel-rds` and replace the placeholder values with your own:
+
+```yaml
+- name: Install New Relic NRDOT for Oracle Database on RDS
+  hosts: all
+  roles:
+    - role: newrelic.newrelic_install
+  vars:
+    targets:
+      - oracle-otel-rds
+  environment:
+    NEW_RELIC_API_KEY: <API key>
+    NEW_RELIC_ACCOUNT_ID: <Account ID>
+    NEW_RELIC_REGION: <Region>
+    NR_CLI_ORACLE_HOST: <RDS Oracle endpoint>
+    NR_CLI_ORACLE_PORT: <Oracle listener port, default 1521>
+    NR_CLI_ORACLE_ADMIN_USER: <RDS master username>
+    NR_CLI_ORACLE_ADMIN_PASSWORD: <RDS master password>
+    NR_CLI_ORACLE_LOGIN_NAME: <monitoring username, default newrelic>
+    NR_CLI_ORACLE_LOGIN_PASSWORD: <monitoring user password>
+    NR_CLI_ORACLE_SERVICE_NAME: <RDS DB service name>
+    NR_CLI_ORACLE_CONFIG_PRESET: <1 for database only, 2 for host and database, default 1>
+```
+
+<Callout variant="tip">
+
+To enable debug logging, add `verbosity: "debug"` under `vars` in the playbook.
+
+</Callout>
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_ORACLE_HOST`</td>
+      <td>**Required.** The RDS Oracle endpoint.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_PORT`</td>
+      <td>Oracle listener port.</td>
+      <td>`1521`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_ADMIN_USER`</td>
+      <td>**Required.** RDS master username, used once to create the monitoring user and grant privileges.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_ADMIN_PASSWORD`</td>
+      <td>**Required.** RDS master password.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_LOGIN_PASSWORD`</td>
+      <td>**Required.**</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_SERVICE_NAME`</td>
+      <td>**Required.** The RDS DB service name for the collector connection.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_CONFIG_PRESET`</td>
+      <td>`1` for database metrics only, `2` for host and database metrics.</td>
+      <td>`1`</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+</CollapserGroup>
+
+</Step>
+
+<Step>
+
+### Run the playbook [#ansible-run]
+
+```bash
+ansible-playbook -i <inventory_file> <playbook_file>.yml
+```
+
+</Step>
+
+</Steps>
+
+To find your Oracle Database entity in New Relic, see [Find and use your data](/docs/opentelemetry/database/otel-oracledb/#find-use-data).
+
+  </TabsPageItem>
+
+  <TabsPageItem id="chef">
+
+You can install and configure the NRDOT Collector for Oracle Database monitoring using the `newrelic-install` Chef cookbook. The cookbook installs the collector, creates the monitoring database user, and configures the collector when you run the `newrelic-install::default` recipe.
+
+<Steps>
+
+<Step>
+
+### Prerequisites [#chef-prerequisites]
+
+* Valid New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key), `NEW_RELIC_API_KEY`, and `NEW_RELIC_ACCOUNT_ID`.
+* Oracle Database 19c or later.
+* Chef 15 or later.
+* For self-hosted Oracle: Oracle Linux 7, 8, or 9, with SSH access (with agent forwarding) to the Oracle Database host where the SSH user can run `sudo su - oracle` without a password prompt.
+* For Oracle on AWS RDS: a collector host running Debian/Ubuntu or CentOS/RHEL/OEL.
+
+</Step>
+
+<Step>
+
+### Download the Chef cookbook [#chef-download-cookbook]
+
+Download the `newrelic-install` [Chef cookbook](https://supermarket.chef.io/cookbooks/newrelic-install) from the Chef Supermarket to your chef-repo directory:
+
+```bash
+knife supermarket install newrelic-install
+```
+
+</Step>
+
+<Step>
+
+### Replace the default attributes [#chef-configure]
+
+Replace the default attributes in `attributes/default.rb` with your account details:
+
+<CollapserGroup>
+
+<Collapser
+  id="chef-host"
+  title="Self-hosted Oracle Database"
+>
+
+```ruby
+default['newrelic_install']['NEW_RELIC_API_KEY']    = <API key>
+default['newrelic_install']['NEW_RELIC_ACCOUNT_ID'] = <Account ID>
+default['newrelic_install']['NEW_RELIC_REGION']     = <Region>
+default['newrelic_install']['targets'] = [
+  'nrdot-collector-oracle'
+]
+default['newrelic_install']['env']['NR_CLI_ORACLE_HOST']           = <Oracle Database host, default localhost>
+default['newrelic_install']['env']['NR_CLI_ORACLE_PORT']           = <Oracle listener port, default 1521>
+default['newrelic_install']['env']['NR_CLI_ORACLE_SSH_USER']       = <SSH user, default opc>
+default['newrelic_install']['env']['NR_CLI_ORACLE_CONTAINER_TYPE'] = <1 for CDB, 2 for PDB, default 1>
+default['newrelic_install']['env']['NR_CLI_ORACLE_PDB_NAME']       = <PDB name, only if container type is 2>
+default['newrelic_install']['env']['NR_CLI_ORACLE_LOGIN_NAME']     = <monitoring username, default newrelic>
+default['newrelic_install']['env']['NR_CLI_ORACLE_LOGIN_PASSWORD'] = <monitoring user password>
+default['newrelic_install']['env']['NR_CLI_ORACLE_SERVICE_NAME']   = <CDB or PDB service name>
+default['newrelic_install']['env']['NR_CLI_ORACLE_CONFIG_PRESET']  = <1 for database only, 2 for host and database, default 1>
+# See all available targets at: https://github.com/newrelic/chef-install
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute (under `env`)</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_ORACLE_HOST`</td>
+      <td>Oracle Database host.</td>
+      <td>`localhost`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_PORT`</td>
+      <td>Oracle listener port.</td>
+      <td>`1521`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_SSH_USER`</td>
+      <td>SSH user for the Oracle Database host, used once to create the monitoring user and grant privileges via OS-authenticated SYSDBA access.</td>
+      <td>`opc`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_CONTAINER_TYPE`</td>
+      <td>Oracle container type: `1` for CDB (monitor all PDBs) or `2` for a single PDB.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_PDB_NAME`</td>
+      <td>PDB name. Required only when `NR_CLI_ORACLE_CONTAINER_TYPE` is `2`.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_LOGIN_NAME`</td>
+      <td>Monitoring username (created as `c##&lt;name&gt;` in CDB mode).</td>
+      <td>`newrelic`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_LOGIN_PASSWORD`</td>
+      <td>**Required.**</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_SERVICE_NAME`</td>
+      <td>**Required.** CDB or PDB service name for the collector connection.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_CONFIG_PRESET`</td>
+      <td>`1` for database metrics only, `2` for host and database metrics.</td>
+      <td>`1`</td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="tip">
+
+No default attribute values are shipped for these variables — set the ones relevant to your target explicitly via `default['newrelic_install']['env'][...]`.
+
+</Callout>
+
+</Collapser>
+
+<Collapser
+  id="chef-rds"
+  title="Oracle Database on AWS RDS"
+>
+
+```ruby
+default['newrelic_install']['NEW_RELIC_API_KEY']    = <API key>
+default['newrelic_install']['NEW_RELIC_ACCOUNT_ID'] = <Account ID>
+default['newrelic_install']['NEW_RELIC_REGION']     = <Region>
+default['newrelic_install']['targets'] = [
+  'nrdot-collector-oracle-rds'
+]
+default['newrelic_install']['env']['NR_CLI_ORACLE_HOST']           = <RDS Oracle endpoint>
+default['newrelic_install']['env']['NR_CLI_ORACLE_PORT']           = <Oracle listener port, default 1521>
+default['newrelic_install']['env']['NR_CLI_ORACLE_ADMIN_USER']     = <RDS master username>
+default['newrelic_install']['env']['NR_CLI_ORACLE_ADMIN_PASSWORD'] = <RDS master password>
+default['newrelic_install']['env']['NR_CLI_ORACLE_LOGIN_NAME']     = <monitoring username, default newrelic>
+default['newrelic_install']['env']['NR_CLI_ORACLE_LOGIN_PASSWORD'] = <monitoring user password>
+default['newrelic_install']['env']['NR_CLI_ORACLE_SERVICE_NAME']   = <RDS DB service name>
+default['newrelic_install']['env']['NR_CLI_ORACLE_CONFIG_PRESET']  = <1 for database only, 2 for host and database, default 1>
+# See all available targets at: https://github.com/newrelic/chef-install
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute (under `env`)</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_ORACLE_HOST`</td>
+      <td>**Required.** The RDS Oracle endpoint.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_PORT`</td>
+      <td>Oracle listener port.</td>
+      <td>`1521`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_ADMIN_USER`</td>
+      <td>**Required.** RDS master username, used once to create the monitoring user and grant privileges.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_ADMIN_PASSWORD`</td>
+      <td>**Required.** RDS master password.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_LOGIN_PASSWORD`</td>
+      <td>**Required.**</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_SERVICE_NAME`</td>
+      <td>**Required.** The RDS DB service name for the collector connection.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_ORACLE_CONFIG_PRESET`</td>
+      <td>`1` for database metrics only, `2` for host and database metrics.</td>
+      <td>`1`</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+</CollapserGroup>
+
+</Step>
+
+<Step>
+
+### Upload the Chef cookbook [#chef-upload-cookbook]
+
+Upload the `newrelic-install` Chef cookbook to your Chef server:
+
+```bash
+knife cookbook upload newrelic-install
+```
+
+</Step>
+
+<Step>
+
+### Update the run list [#chef-run-list]
+
+Add the `newrelic-install` recipe to the run list of a node:
+
+```json
+"run_list": [
+  "recipe[newrelic-install]"
+]
+```
+
+</Step>
+
+</Steps>
+
+To find your Oracle Database entity in New Relic, see [Find and use your data](/docs/opentelemetry/database/otel-oracledb/#find-use-data).
+
+  </TabsPageItem>
+
+  <TabsPageItem id="helm">
+
+You can install and configure Oracle Database monitoring on Kubernetes using the `oracle-otel` Helm chart. Depending on how you provide credentials, the chart can also run a setup job that creates the monitoring database user for you.
+
+<Steps>
+
+<Step>
+
+### Prerequisites [#helm-prerequisites]
+
+* Valid New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).
+* Helm 3.0 or later, and `kubectl` configured to access your Kubernetes cluster.
+* Network connectivity from your Kubernetes cluster to the Oracle Database host and listener port.
+* Either a monitoring database user you've already created, or Oracle Database admin credentials (RDS master user, `SYS`, or `ADMIN`) so the chart's setup job can create one for you. See [Configure monitoring credentials](#helm-credentials) below.
+
+</Step>
+
+<Step>
+
+### Create the namespace [#helm-namespace]
+
+Create the namespace you'll install into. It must exist before you create any secrets in the next step, since `helm install --create-namespace` only creates the namespace during the final install step:
+
+```bash
+kubectl create namespace newrelic
+```
+
+<Callout variant="tip">
+
+  Set it as the default namespace for your current `kubectl` context so you don't need to pass `-n` on every command below:
+
+  ```bash
+  kubectl config set-context --current --namespace=newrelic
+  ```
+
+</Callout>
+
+</Step>
+
+<Step>
+
+### Configure monitoring credentials [#helm-credentials]
+
+Choose how the chart should get the Oracle Database monitoring user's credentials:
+
+<CollapserGroup>
+
+<Collapser
+  id="helm-creds-inline"
+  title="Plain username and password"
+>
+
+With this method there's no setup job, so nothing here creates the monitoring user for you. Before installing the chart, create it yourself: switch to the **On-host** tab above and follow its **Configure database user** and **Grant monitoring privileges** steps for your environment (CDB or PDB).
+
+You'll set the monitoring username and password directly in `values.yaml` in the next step.
+
+</Collapser>
+
+<Collapser
+  id="helm-creds-secret"
+  title="Secret-based credentials"
+>
+
+With this method, the chart's setup job creates the monitoring user for you using database admin credentials.
+
+1. Create a secret with the monitoring username and password. This is the identity the setup job creates and the collector connects with:
+
+    ```bash
+    kubectl create secret generic oracle-monitor-creds \
+      --from-literal=username=<MONITORING_USERNAME> \
+      --from-literal=password='<MONITORING_PASSWORD>' \
+      -n newrelic
+    ```
+
+2. The setup job only accepts admin credentials via a Kubernetes secret (no plaintext username/password in `values.yaml`). Since this credential can create users and grant broad database access, create it as its own secret:
+
+    ```bash
+    kubectl create secret generic oracle-admin-creds \
+      --from-literal=username=<ADMIN_USERNAME> \
+      --from-literal=password='<ADMIN_PASSWORD>' \
+      -n newrelic
+    ```
+
+</Collapser>
+
+</CollapserGroup>
+
+</Step>
+
+<Step>
+
+### Configure the Helm values [#helm-configure]
+
+Set `oracle.topology` to match your environment:
+
+<table>
+  <thead>
+    <tr>
+      <th>Value</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`cdb`</td>
+      <td>On-host, multitenant CDB. All PDBs under this CDB are monitored.</td>
+    </tr>
+    <tr>
+      <td>`pdb`</td>
+      <td>On-host, single PDB.</td>
+    </tr>
+    <tr>
+      <td>`rds`</td>
+      <td>Oracle Database on AWS RDS.</td>
+    </tr>
+    <tr>
+      <td>`adb`</td>
+      <td>Oracle Autonomous Database.</td>
+    </tr>
+  </tbody>
+</table>
+
+Use the `values.yaml` that matches the credential method you chose in the previous step:
+
+<CollapserGroup>
+
+<Collapser
+  id="helm-values-inline"
+  title="Plain username and password"
+>
+
+```yaml
+licenseKey: <YOUR_LICENSE_KEY>
+otlpEndpoint: otlp.nr-data.net:4317
+
+oracle:
+  topology: <cdb|pdb|rds|adb>
+  endpoint: <YOUR_DB_HOST>:<YOUR_DB_PORT>
+  service: <YOUR_SERVICE_NAME>
+  username: <YOUR_MONITORING_USERNAME>
+  password: <YOUR_MONITORING_PASSWORD>
+
+# setupJob.oracleAdmin only ever accepts existingSecret (no
+# plaintext username/password), and since this credential
+# can create users and grant broad database access, the
+# setup job is only ever enabled for Secret-based
+# credentials. Create the monitoring user yourself before
+# installing the chart.
+setupJob:
+  enabled: false
+```
+
+</Collapser>
+
+<Collapser
+  id="helm-values-secret"
+  title="Secret-based credentials"
+>
+
+```yaml
+licenseKey: <YOUR_LICENSE_KEY>
+otlpEndpoint: otlp.nr-data.net:4317
+
+oracle:
+  topology: <cdb|pdb|rds|adb>
+  endpoint: <YOUR_DB_HOST>:<YOUR_DB_PORT>
+  service: <YOUR_SERVICE_NAME>
+  existingSecret: oracle-monitor-creds
+
+setupJob:
+  enabled: true
+  image:
+    # -- Oracle Instant Client + sqlplus image. No default: pulling from container-registry.oracle.com requires accepting Oracle's license terms first. See README.
+    repository: ""
+    tag: ""
+    pullPolicy: IfNotPresent
+  oracleAdmin:
+    existingSecret: oracle-admin-creds
+```
+
+</Collapser>
+
+</CollapserGroup>
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`licenseKey`</td>
+      <td>Your New Relic license key.</td>
+    </tr>
+    <tr>
+      <td>`otlpEndpoint`</td>
+      <td>Your region's OTLP endpoint: `otlp.nr-data.net:4317` (US) or `otlp.eu01.nr-data.net:4317` (EU). For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/).</td>
+    </tr>
+    <tr>
+      <td>`oracle.endpoint`</td>
+      <td>Your Oracle Database host (or RDS endpoint) and listener port, reachable from the cluster.</td>
+    </tr>
+    <tr>
+      <td>`oracle.service`</td>
+      <td>Your CDB, PDB, RDS, or ADB service name for the collector connection.</td>
+    </tr>
+    <tr>
+      <td>`setupJob.image.repository` / `setupJob.image.tag`</td>
+      <td>An Oracle Instant Client + `sqlplus` image used by the setup job. There's no default: pulling from `container-registry.oracle.com` requires accepting Oracle's license terms first, so you must supply your own image. Only required for secret-based credentials, where the setup job is enabled.</td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="tip">
+
+  See the chart's [values.yaml](https://github.com/newrelic/helm-charts/blob/master/charts/oracle-otel/values.yaml) for all available configuration options.
+
+</Callout>
+
+</Step>
+
+<Step>
+
+### Install the Helm chart [#helm-install]
+
+1. Add the New Relic Helm repository:
+
+    ```bash
+    helm repo add newrelic https://helm-charts.newrelic.com
+    helm repo update
+    ```
+
+2. Install the chart using your `values.yaml` file:
+
+    ```bash
+    helm upgrade --install oracle-otel newrelic/oracle-otel \
+      -n newrelic \
+      --create-namespace \
+      -f values.yaml
+    ```
+
+</Step>
+
+<Step>
+
+### Verify the installation [#helm-verify]
+
+1. Check that the setup job completed and the collector pod is running:
+
+    ```bash
+    kubectl get jobs,pods -n newrelic --watch
+    ```
+
+2. Run this query in the [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder/) to confirm data is arriving:
+
+    ```sql
+    SELECT count(*) FROM Metric
+    WHERE metricName LIKE 'oracledb.%'
+    AND instrumentation.provider = 'opentelemetry'
+    SINCE 10 minutes ago
+    ```
+
+</Step>
+
+</Steps>
+
+To find your Oracle Database entity in New Relic, see [Find and use your data](/docs/opentelemetry/database/otel-oracledb/#find-use-data).
+
+  </TabsPageItem>
+
         <TabsPageItem id="host">
 
 <Tabs>

--- a/src/content/docs/opentelemetry/database/postgresql/ansible.mdx
+++ b/src/content/docs/opentelemetry/database/postgresql/ansible.mdx
@@ -1,0 +1,273 @@
+---
+title: "Ansible install for PostgreSQL monitoring with NRDOT"
+tags:
+  - OpenTelemetry
+  - NRDOT
+  - PostgreSQL
+  - Ansible
+metaDescription: Install and configure the NRDOT Collector for PostgreSQL monitoring using the newrelic.newrelic_install Ansible role
+freshnessValidatedDate: never
+---
+
+<Callout title="Preview">
+  We're still working on this feature, but we'd love for you to try it out!
+
+  This feature is currently provided as part of a preview pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
+</Callout>
+
+You can install and configure the NRDOT Collector for PostgreSQL monitoring using the `newrelic.newrelic_install` Ansible role. The role installs the collector, creates the monitoring role and its grants, and configures the collector in a single play.
+
+<Steps>
+
+<Step>
+
+## Prerequisites [#prerequisites]
+
+* New Relic account with a valid [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key), `NEW_RELIC_API_KEY`, and `NEW_RELIC_ACCOUNT_ID`.
+* PostgreSQL 14 or later.
+* Ansible Core 2.13 or 2.14 (versions before 2.10 aren't supported), Python 3.10, and the `ansible.windows` and `ansible.utils` collections.
+* A Linux collector host running Debian/Ubuntu or RHEL/CentOS.
+* This integration is available as a part of New Relic public preview program. Check with your Organization Manager to opt in from the [Previews & Trials](https://one.newrelic.com/admin-portal/promotion-management/home) page.
+* `pg_stat_statements` must be loaded via `shared_preload_libraries`, which requires a database restart. Put the [server-level prerequisites](/docs/opentelemetry/database/postgresql/cli/#server-prereqs) in place before running the playbook.
+* For self-hosted PostgreSQL: administrative access to your PostgreSQL server (the `postgres` superuser or equivalent), with a password set and `pg_hba.conf` permitting password-based host authentication.
+* For PostgreSQL or Aurora on AWS RDS: network connectivity from the collector host to the RDS endpoint, and the RDS master username and password.
+* Network connectivity to [New Relic OTLP endpoint](/docs/opentelemetry/best-practices/opentelemetry-otlp) for your region.
+
+For detailed requirements, refer to [Compatibility](/docs/opentelemetry/database/postgresql/compatibility).
+
+</Step>
+
+<Step>
+
+## Install the role [#ansible-install-role]
+
+```bash
+ansible-galaxy install newrelic.newrelic_install
+```
+
+Make sure the required collections are also installed:
+
+```bash
+ansible-galaxy collection install ansible.windows ansible.utils
+```
+
+</Step>
+
+<Step>
+
+## Configure the playbook [#ansible-configure]
+
+<CollapserGroup>
+
+<Collapser
+  id="ansible-host"
+  title="Self-hosted PostgreSQL"
+>
+
+Create a file named `playbook.yml` and copy the following content into it. Set `targets` to `postgresql-otel` and replace the placeholder values with your own:
+
+```yaml
+- name: Install New Relic NRDOT for PostgreSQL
+  hosts: all
+  roles:
+    - role: newrelic.newrelic_install
+  vars:
+    targets:
+      - postgresql-otel
+  environment:
+    NEW_RELIC_API_KEY: <API key>
+    NEW_RELIC_ACCOUNT_ID: <Account ID>
+    NEW_RELIC_REGION: <Region>
+    NR_CLI_POSTGRES_CONFIG_PRESET: <1 for Standard, 2 for Full-feature, default 1>
+    NR_CLI_POSTGRES_SERVER: <PostgreSQL host, default localhost>
+    NR_CLI_POSTGRES_PORT: <PostgreSQL port, default 5432>
+    NR_CLI_POSTGRES_SUPERUSER_PASSWORD: <postgres superuser password>
+    NR_CLI_POSTGRES_LOGIN_NAME: <monitoring username, default newrelic>
+    NR_CLI_POSTGRES_DATABASES: <comma-separated databases to monitor>
+```
+
+<Callout variant="important">
+  The role connects to PostgreSQL over TCP using a password, so `postgres` must have a password set and `pg_hba.conf` must permit password-based host authentication (`md5` or `scram-sha-256`) for TCP connections:
+
+  ```bash
+  sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD '<password>';"
+  ```
+
+  On RHEL/CentOS, the default `pg_hba.conf` often doesn't permit password-based host authentication at all — verify and update it, then reload PostgreSQL before running the playbook.
+</Callout>
+
+<Callout variant="tip">
+
+To enable debug logging, add `verbosity: "debug"` under `vars` in the playbook.
+
+</Callout>
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_POSTGRES_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_SERVER`</td>
+      <td>PostgreSQL host.</td>
+      <td>`localhost`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_PORT`</td>
+      <td>PostgreSQL port.</td>
+      <td>`5432`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_SUPERUSER_PASSWORD`</td>
+      <td>**Required.** PostgreSQL `postgres` superuser password, used once to create the monitoring role.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_DATABASES`</td>
+      <td>**Required.** Comma-separated list of databases to monitor. At least one is required.</td>
+      <td>None</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+<Collapser
+  id="ansible-rds"
+  title="PostgreSQL or Aurora on AWS RDS"
+>
+
+Create a file named `playbook.yml` and copy the following content into it. Set `targets` to `postgresql-otel-rds` and replace the placeholder values with your own:
+
+```yaml
+- name: Install New Relic NRDOT for PostgreSQL on RDS
+  hosts: all
+  roles:
+    - role: newrelic.newrelic_install
+  vars:
+    targets:
+      - postgresql-otel-rds
+  environment:
+    NEW_RELIC_API_KEY: <API key>
+    NEW_RELIC_ACCOUNT_ID: <Account ID>
+    NEW_RELIC_REGION: <Region>
+    NR_CLI_POSTGRES_CONFIG_PRESET: <1 for Standard, 2 for Full-feature, default 1>
+    NR_CLI_POSTGRES_SERVER: <RDS PostgreSQL or Aurora endpoint>
+    NR_CLI_POSTGRES_PORT: <PostgreSQL port, default 5432>
+    NR_CLI_POSTGRES_MASTER_USER: <RDS master username>
+    NR_CLI_POSTGRES_MASTER_PASSWORD: <RDS master password>
+    NR_CLI_POSTGRES_LOGIN_NAME: <monitoring username, default newrelic>
+    NR_CLI_POSTGRES_DATABASES: <comma-separated databases to monitor>
+```
+
+<Callout variant="tip">
+
+To enable debug logging, add `verbosity: "debug"` under `vars` in the playbook.
+
+</Callout>
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_POSTGRES_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_SERVER`</td>
+      <td>**Required.** RDS PostgreSQL or Aurora endpoint. Unlike the self-hosted target, there's no default.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_PORT`</td>
+      <td>PostgreSQL port.</td>
+      <td>`5432`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_MASTER_USER`</td>
+      <td>**Required.** RDS master username, used once to create the monitoring role.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_MASTER_PASSWORD`</td>
+      <td>**Required.** RDS master password.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_DATABASES`</td>
+      <td>**Required.** Comma-separated list of databases to monitor. At least one is required.</td>
+      <td>None</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+</CollapserGroup>
+
+<Callout variant="tip">
+  To securely manage sensitive information, such as database credentials, store them in [secret management](/docs/opentelemetry/database/capabilities/db-apm/#secret-management) tools, for example with [Ansible Vault](https://docs.ansible.com/ansible/latest/vault_guide/index.html).
+</Callout>
+
+</Step>
+
+<Step>
+
+## Run the playbook [#ansible-run]
+
+```bash
+ansible-playbook -i <inventory_file> <playbook_file>.yml
+```
+
+</Step>
+
+<Step>
+
+## Find and use your data [#find]
+
+Once your data is being collected, you can access comprehensive PostgreSQL database monitoring through the New Relic UI.
+
+To find your PostgreSQL database entity in New Relic:
+
+1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com) > All capabilities > Databases**</DNT>.
+2. From the **<DNT>Entity type</DNT>** dropdown, select <DNT>**PostgreSQL instance**</DNT>, then click <DNT>**Apply**</DNT>.
+3. Select your PostgreSQL database from the list of entities.
+
+</Step>
+
+</Steps>
+
+## Related documentation [#related]
+
+<DocTiles>
+  <DocTile title="Introduction to PostgreSQL monitoring with NRDOT" path="/docs/opentelemetry/database/postgresql/introduction">Learn about all the available installation methods for PostgreSQL monitoring with New Relic.</DocTile>
+  <DocTile title="CLI install" path="/docs/opentelemetry/database/postgresql/cli">Learn how to install and configure PostgreSQL monitoring with a single New Relic CLI command.</DocTile>
+  <DocTile title="Chef install" path="/docs/opentelemetry/database/postgresql/chef">Learn how to install and configure PostgreSQL monitoring at scale with the newrelic-install Chef cookbook.</DocTile>
+  <DocTile title="Helm chart install" path="/docs/opentelemetry/database/postgresql/helm">Learn how to install and configure PostgreSQL monitoring on Kubernetes with the postgresql-otel Helm chart.</DocTile>
+</DocTiles>

--- a/src/content/docs/opentelemetry/database/postgresql/chef.mdx
+++ b/src/content/docs/opentelemetry/database/postgresql/chef.mdx
@@ -1,0 +1,273 @@
+---
+title: "Chef install for PostgreSQL monitoring with NRDOT"
+tags:
+  - OpenTelemetry
+  - NRDOT
+  - PostgreSQL
+  - Chef
+metaDescription: Install and configure the NRDOT Collector for PostgreSQL monitoring using the newrelic-install Chef cookbook
+freshnessValidatedDate: never
+---
+
+<Callout title="Preview">
+  We're still working on this feature, but we'd love for you to try it out!
+
+  This feature is currently provided as part of a preview pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
+</Callout>
+
+You can install and configure the NRDOT Collector for PostgreSQL monitoring using the `newrelic-install` Chef cookbook. The cookbook installs the collector, creates the monitoring role and its grants, and configures the collector when you run the `newrelic-install::default` recipe.
+
+<Steps>
+
+<Step>
+
+## Prerequisites [#prerequisites]
+
+* New Relic account with a valid [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key), `NEW_RELIC_API_KEY`, and `NEW_RELIC_ACCOUNT_ID`.
+* PostgreSQL 14 or later.
+* Chef 15 or later.
+* A Linux collector host running Debian/Ubuntu or RHEL/CentOS.
+* This integration is available as a part of New Relic public preview program. Check with your Organization Manager to opt in from the [Previews & Trials](https://one.newrelic.com/admin-portal/promotion-management/home) page.
+* `pg_stat_statements` must be loaded via `shared_preload_libraries`, which requires a database restart. Put the [server-level prerequisites](/docs/opentelemetry/database/postgresql/cli/#server-prereqs) in place before running the recipe.
+* For self-hosted PostgreSQL: administrative access to your PostgreSQL server (the `postgres` superuser or equivalent), with a password set and `pg_hba.conf` permitting password-based host authentication.
+* For PostgreSQL or Aurora on AWS RDS: network connectivity from the collector host to the RDS endpoint, and the RDS master username and password.
+* Network connectivity to [New Relic OTLP endpoint](/docs/opentelemetry/best-practices/opentelemetry-otlp) for your region.
+
+For detailed requirements, refer to [Compatibility](/docs/opentelemetry/database/postgresql/compatibility).
+
+</Step>
+
+<Step>
+
+## Download the Chef cookbook [#chef-download-cookbook]
+
+Download the `newrelic-install` [Chef cookbook](https://supermarket.chef.io/cookbooks/newrelic-install) from the Chef Supermarket to your chef-repo directory:
+
+```bash
+knife supermarket install newrelic-install
+```
+
+</Step>
+
+<Step>
+
+## Replace the default attributes [#chef-configure]
+
+Replace the default attributes in `attributes/default.rb` with your account details:
+
+<CollapserGroup>
+
+<Collapser
+  id="chef-host"
+  title="Self-hosted PostgreSQL"
+>
+
+```ruby
+default['newrelic_install']['NEW_RELIC_API_KEY']    = <API key>
+default['newrelic_install']['NEW_RELIC_ACCOUNT_ID'] = <Account ID>
+default['newrelic_install']['NEW_RELIC_REGION']     = <Region>
+default['newrelic_install']['targets'] = [
+  'nrdot-collector-postgresql'
+]
+default['newrelic_install']['env']['NR_CLI_POSTGRES_CONFIG_PRESET']      = <1 for Standard, 2 for Full-feature, default 1>
+default['newrelic_install']['env']['NR_CLI_POSTGRES_SERVER']             = <PostgreSQL host, default localhost>
+default['newrelic_install']['env']['NR_CLI_POSTGRES_PORT']               = <PostgreSQL port, default 5432>
+default['newrelic_install']['env']['NR_CLI_POSTGRES_SUPERUSER_PASSWORD'] = <postgres superuser password>
+default['newrelic_install']['env']['NR_CLI_POSTGRES_LOGIN_NAME']         = <monitoring username, default newrelic>
+default['newrelic_install']['env']['NR_CLI_POSTGRES_DATABASES']          = <comma-separated databases to monitor>
+# See all available targets at: https://github.com/newrelic/chef-install
+```
+
+<Callout variant="important">
+  The cookbook connects to PostgreSQL over TCP using a password, so `postgres` must have a password set and `pg_hba.conf` must permit password-based host authentication (`md5` or `scram-sha-256`) for TCP connections:
+
+  ```bash
+  sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD '<password>';"
+  ```
+</Callout>
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute (under `env`)</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_POSTGRES_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_SERVER`</td>
+      <td>PostgreSQL host.</td>
+      <td>`localhost`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_PORT`</td>
+      <td>PostgreSQL port.</td>
+      <td>`5432`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_SUPERUSER_PASSWORD`</td>
+      <td>**Required.** PostgreSQL `postgres` superuser password, used once to create the monitoring role.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_DATABASES`</td>
+      <td>**Required.** Comma-separated list of databases to monitor. At least one is required.</td>
+      <td>None</td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="tip">
+
+No default attribute values are shipped for these variables — set the ones relevant to your target explicitly via `default['newrelic_install']['env'][...]`.
+
+</Callout>
+
+</Collapser>
+
+<Collapser
+  id="chef-rds"
+  title="PostgreSQL or Aurora on AWS RDS"
+>
+
+```ruby
+default['newrelic_install']['NEW_RELIC_API_KEY']    = <API key>
+default['newrelic_install']['NEW_RELIC_ACCOUNT_ID'] = <Account ID>
+default['newrelic_install']['NEW_RELIC_REGION']     = <Region>
+default['newrelic_install']['targets'] = [
+  'nrdot-collector-postgresql-rds'
+]
+default['newrelic_install']['env']['NR_CLI_POSTGRES_CONFIG_PRESET']   = <1 for Standard, 2 for Full-feature, default 1>
+default['newrelic_install']['env']['NR_CLI_POSTGRES_SERVER']          = <RDS PostgreSQL or Aurora endpoint>
+default['newrelic_install']['env']['NR_CLI_POSTGRES_PORT']            = <PostgreSQL port, default 5432>
+default['newrelic_install']['env']['NR_CLI_POSTGRES_MASTER_USER']     = <RDS master username>
+default['newrelic_install']['env']['NR_CLI_POSTGRES_MASTER_PASSWORD'] = <RDS master password>
+default['newrelic_install']['env']['NR_CLI_POSTGRES_LOGIN_NAME']      = <monitoring username, default newrelic>
+default['newrelic_install']['env']['NR_CLI_POSTGRES_DATABASES']       = <comma-separated databases to monitor>
+# See all available targets at: https://github.com/newrelic/chef-install
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute (under `env`)</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_POSTGRES_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_SERVER`</td>
+      <td>**Required.** RDS PostgreSQL or Aurora endpoint.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_PORT`</td>
+      <td>PostgreSQL port.</td>
+      <td>`5432`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_MASTER_USER`</td>
+      <td>**Required.** RDS master username, used once to create the monitoring role.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_MASTER_PASSWORD`</td>
+      <td>**Required.** RDS master password.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_DATABASES`</td>
+      <td>**Required.** Comma-separated list of databases to monitor. At least one is required.</td>
+      <td>None</td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="tip">
+
+No default attribute values are shipped for these variables — set the ones relevant to your target explicitly via `default['newrelic_install']['env'][...]`.
+
+</Callout>
+
+</Collapser>
+
+</CollapserGroup>
+
+<Callout variant="tip">
+  To securely manage sensitive information, such as database credentials, store them in [secret management](/docs/opentelemetry/database/capabilities/db-apm/#secret-management) tools, for example with [Chef encrypted data bags](https://docs.chef.io/data_bags/#encrypt-a-data-bag-item).
+</Callout>
+
+</Step>
+
+<Step>
+
+## Upload the Chef cookbook [#chef-upload-cookbook]
+
+Upload the `newrelic-install` Chef cookbook to your Chef server:
+
+```bash
+knife cookbook upload newrelic-install
+```
+
+</Step>
+
+<Step>
+
+## Update the run list [#chef-run-list]
+
+Add the `newrelic-install` recipe to the run list of a node:
+
+```json
+"run_list": [
+  "recipe[newrelic-install]"
+]
+```
+
+</Step>
+
+<Step>
+
+## Find and use your data [#find]
+
+Once your data is being collected, you can access comprehensive PostgreSQL database monitoring through the New Relic UI.
+
+To find your PostgreSQL database entity in New Relic:
+
+1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com) > All capabilities > Databases**</DNT>.
+2. From the **<DNT>Entity type</DNT>** dropdown, select <DNT>**PostgreSQL instance**</DNT>, then click <DNT>**Apply**</DNT>.
+3. Select your PostgreSQL database from the list of entities.
+
+</Step>
+
+</Steps>
+
+## Related documentation [#related]
+
+<DocTiles>
+  <DocTile title="Introduction to PostgreSQL monitoring with NRDOT" path="/docs/opentelemetry/database/postgresql/introduction">Learn about all the available installation methods for PostgreSQL monitoring with New Relic.</DocTile>
+  <DocTile title="CLI install" path="/docs/opentelemetry/database/postgresql/cli">Learn how to install and configure PostgreSQL monitoring with a single New Relic CLI command.</DocTile>
+  <DocTile title="Ansible install" path="/docs/opentelemetry/database/postgresql/ansible">Learn how to install and configure PostgreSQL monitoring at scale with the newrelic.newrelic_install Ansible role.</DocTile>
+  <DocTile title="Helm chart install" path="/docs/opentelemetry/database/postgresql/helm">Learn how to install and configure PostgreSQL monitoring on Kubernetes with the postgresql-otel Helm chart.</DocTile>
+</DocTiles>

--- a/src/content/docs/opentelemetry/database/postgresql/cli.mdx
+++ b/src/content/docs/opentelemetry/database/postgresql/cli.mdx
@@ -1,0 +1,272 @@
+---
+title: "CLI install for PostgreSQL monitoring with NRDOT"
+tags:
+  - OpenTelemetry
+  - NRDOT
+  - PostgreSQL
+  - CLI
+metaDescription: Install and configure the NRDOT Collector for PostgreSQL monitoring using the New Relic CLI
+freshnessValidatedDate: never
+---
+
+<Callout title="Preview">
+  We're still working on this feature, but we'd love for you to try it out!
+
+  This feature is currently provided as part of a preview pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
+</Callout>
+
+You can install and configure the NRDOT Collector for PostgreSQL monitoring using the New Relic CLI. The CLI installs the collector, creates the monitoring role and its grants, and configures the collector in a single command.
+
+<Steps>
+
+<Step>
+
+## Prerequisites [#prerequisites]
+
+* New Relic account with a valid [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key), `NEW_RELIC_API_KEY`, and `NEW_RELIC_ACCOUNT_ID`.
+* PostgreSQL 14 or later.
+* A Linux collector host running Debian/Ubuntu or RHEL/CentOS, with `curl` and `systemd` installed, and the `psql` client available.
+* This integration is available as a part of New Relic public preview program. Check with your Organization Manager to opt in from the [Previews & Trials](https://one.newrelic.com/admin-portal/promotion-management/home) page.
+* `pg_stat_statements` must be loaded via `shared_preload_libraries`. The installer checks this and fails if it isn't — see [Server-level prerequisites](#server-prereqs) below.
+* For self-hosted PostgreSQL: administrative access to your PostgreSQL server (the `postgres` superuser or equivalent).
+* For PostgreSQL or Aurora on AWS RDS: network connectivity from the collector host to the RDS endpoint (inbound access on the PostgreSQL port in the RDS security group), and the RDS master username and password.
+* Network connectivity to [New Relic OTLP endpoint](/docs/opentelemetry/best-practices/opentelemetry-otlp) for your region.
+
+For detailed requirements, refer to [Compatibility](/docs/opentelemetry/database/postgresql/compatibility).
+
+</Step>
+
+<Step>
+
+## Server-level prerequisites [#server-prereqs]
+
+`pg_stat_statements` can't be created without `shared_preload_libraries`, and that parameter requires a database **restart** — so the CLI can't configure it for you. Put these parameters in place before running the install:
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`shared_preload_libraries`</td>
+      <td>`pg_stat_statements`</td>
+    </tr>
+    <tr>
+      <td>`pg_stat_statements.track`</td>
+      <td>`ALL`</td>
+    </tr>
+    <tr>
+      <td>`pg_stat_statements.max`</td>
+      <td>`10000`</td>
+    </tr>
+    <tr>
+      <td>`pg_stat_statements.save`</td>
+      <td>`on`</td>
+    </tr>
+    <tr>
+      <td>`track_activity_query_size`</td>
+      <td>`4096`</td>
+    </tr>
+    <tr>
+      <td>`track_functions`</td>
+      <td>`all`</td>
+    </tr>
+  </tbody>
+</table>
+
+* **Self-hosted**: set these in `postgresql.conf`, then restart PostgreSQL. Some distributions need the `postgresql-contrib` package installed for `pg_stat_statements` to be available.
+* **AWS RDS or Aurora**: set these in the DB **parameter group**, not a config file. `track_activity_query_size` and `pg_stat_statements.max` are static parameters — apply them with `apply_method: pending-reboot`, then reboot the instance. For Aurora, the parameter-group family name must match your engine's major version exactly, for example `aurora-postgresql16`.
+
+</Step>
+
+<Step>
+
+## Install and configure the NRDOT Collector [#cli-install]
+
+<CollapserGroup>
+
+<Collapser
+  id="cli-host"
+  title="Self-hosted PostgreSQL"
+>
+
+Before you run this command, have ready:
+
+* PostgreSQL host and port
+* The `postgres` superuser password (used once to create the monitoring role)
+* Monitoring username (leave the default `newrelic`, or choose your own)
+* The list of databases you want to monitor
+* Whether you want Standard or Full-feature metrics
+
+```bash
+curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && sudo NEW_RELIC_API_KEY=INSERT_YOUR_API_KEY NEW_RELIC_ACCOUNT_ID=INSERT_YOUR_ACCOUNT_ID NEW_RELIC_REGION=INSERT_YOUR_REGION /usr/local/bin/newrelic install -n nrdot-collector-postgresql
+```
+
+<Callout variant="important">
+  This installer connects to PostgreSQL over TCP using a password, so `postgres` must have a password set and `pg_hba.conf` must permit password-based host authentication (`md5` or `scram-sha-256`) for TCP connections. A fresh install has no password set on `postgres` by default — set one first:
+
+  ```bash
+  sudo -u postgres psql -c "ALTER USER postgres WITH PASSWORD '<password>';"
+  ```
+
+  On RHEL/CentOS, the default `pg_hba.conf` often doesn't permit password-based host authentication at all — verify and update it, then reload PostgreSQL before running the install.
+</Callout>
+
+The CLI prompts interactively for the following variables. You can also set them ahead of time as environment variables to run non-interactively.
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_POSTGRES_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_SERVER`</td>
+      <td>PostgreSQL host.</td>
+      <td>`localhost`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_PORT`</td>
+      <td>PostgreSQL port.</td>
+      <td>`5432`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_SUPERUSER_PASSWORD`</td>
+      <td>**Required.** PostgreSQL `postgres` superuser password, used once to create the monitoring role.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_DATABASES`</td>
+      <td>**Required.** Comma-separated list of databases to monitor. PostgreSQL has no monitor-all-databases mode, so at least one is required.</td>
+      <td>None</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+<Collapser
+  id="cli-rds"
+  title="PostgreSQL or Aurora on AWS RDS"
+>
+
+Before you run this command, have ready:
+
+* RDS PostgreSQL or Aurora endpoint and port
+* RDS master username and password
+* Monitoring username (leave the default `newrelic`, or choose your own)
+* The list of databases you want to monitor
+* Whether you want Standard or Full-feature metrics
+
+```bash
+curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && sudo NEW_RELIC_API_KEY=INSERT_YOUR_API_KEY NEW_RELIC_ACCOUNT_ID=INSERT_YOUR_ACCOUNT_ID NEW_RELIC_REGION=INSERT_YOUR_REGION /usr/local/bin/newrelic install -n nrdot-collector-postgresql-rds
+```
+
+The CLI prompts interactively for the following variables. You can also set them ahead of time as environment variables to run non-interactively.
+
+<table>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+      <th>Default</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`NR_CLI_POSTGRES_CONFIG_PRESET`</td>
+      <td>NRDOT configuration: `1` for Standard, `2` for Full-feature.</td>
+      <td>`1`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_SERVER`</td>
+      <td>**Required.** RDS PostgreSQL or Aurora endpoint.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_PORT`</td>
+      <td>PostgreSQL port.</td>
+      <td>`5432`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_MASTER_USER`</td>
+      <td>**Required.** RDS master username, used once to create the monitoring role.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_MASTER_PASSWORD`</td>
+      <td>**Required.** RDS master user password.</td>
+      <td>None</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_LOGIN_NAME`</td>
+      <td>Monitoring username.</td>
+      <td>`newrelic`</td>
+    </tr>
+    <tr>
+      <td>`NR_CLI_POSTGRES_DATABASES`</td>
+      <td>**Required.** Comma-separated list of databases to monitor. PostgreSQL has no monitor-all-databases mode, so at least one is required.</td>
+      <td>None</td>
+    </tr>
+  </tbody>
+</table>
+
+</Collapser>
+
+</CollapserGroup>
+
+<Callout variant="tip">
+  To securely manage sensitive information, such as database credentials, store them in [secret management](/docs/opentelemetry/database/capabilities/db-apm/#secret-management) tools.
+</Callout>
+
+</Step>
+
+<Step>
+
+## Find and use your data [#find]
+
+Once your data is being collected, you can access comprehensive PostgreSQL database monitoring through the New Relic UI.
+
+To find your PostgreSQL database entity in New Relic:
+
+1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com) > All capabilities > Databases**</DNT>.
+2. From the **<DNT>Entity type</DNT>** dropdown, select <DNT>**PostgreSQL instance**</DNT>, then click <DNT>**Apply**</DNT>.
+3. Select your PostgreSQL database from the list of entities.
+
+To confirm data is arriving, run this query in the [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder/):
+
+```sql
+SELECT count(*) FROM Metric
+WHERE metricName LIKE 'postgresql.%'
+AND instrumentation.provider = 'opentelemetry'
+SINCE 10 minutes ago
+```
+
+</Step>
+
+</Steps>
+
+## Related documentation [#related]
+
+<DocTiles>
+  <DocTile title="Introduction to PostgreSQL monitoring with NRDOT" path="/docs/opentelemetry/database/postgresql/introduction">Learn about all the available installation methods for PostgreSQL monitoring with New Relic.</DocTile>
+  <DocTile title="Ansible install" path="/docs/opentelemetry/database/postgresql/ansible">Learn how to install and configure PostgreSQL monitoring at scale with the newrelic.newrelic_install Ansible role.</DocTile>
+  <DocTile title="Chef install" path="/docs/opentelemetry/database/postgresql/chef">Learn how to install and configure PostgreSQL monitoring at scale with the newrelic-install Chef cookbook.</DocTile>
+  <DocTile title="Helm chart install" path="/docs/opentelemetry/database/postgresql/helm">Learn how to install and configure PostgreSQL monitoring on Kubernetes with the postgresql-otel Helm chart.</DocTile>
+</DocTiles>

--- a/src/content/docs/opentelemetry/database/postgresql/helm.mdx
+++ b/src/content/docs/opentelemetry/database/postgresql/helm.mdx
@@ -1,0 +1,398 @@
+---
+title: "Helm chart install for PostgreSQL monitoring with NRDOT"
+tags:
+  - OpenTelemetry
+  - NRDOT
+  - PostgreSQL
+  - Kubernetes
+  - Helm
+metaDescription: Install and configure PostgreSQL monitoring on Kubernetes using the postgresql-otel Helm chart
+freshnessValidatedDate: never
+---
+
+<Callout title="Preview">
+  We're still working on this feature, but we'd love for you to try it out!
+
+  This feature is currently provided as part of a preview pursuant to our [pre-release policies](/docs/licenses/license-information/referenced-policies/new-relic-pre-release-policy/).
+</Callout>
+
+You can install and configure PostgreSQL monitoring on Kubernetes using the `postgresql-otel` Helm chart. Depending on how you provide credentials, the chart can also run a setup job that creates the monitoring role, its grants, and the `pg_stat_statements` extension for you.
+
+<Callout variant="important">
+  The chart deploys the collector as a Kubernetes Deployment that reaches PostgreSQL remotely over the network, so it reports PostgreSQL metrics only — no host or infrastructure metrics for the machine PostgreSQL runs on. It monitors one PostgreSQL *instance* per release (multiple *databases* on that instance are supported), and it doesn't configure TLS or `db_auth` credential providers such as AWS IAM authentication.
+</Callout>
+
+<Steps>
+
+<Step>
+
+### Server-level prerequisites [#helm-server-prereqs]
+
+PostgreSQL **14 or newer** is required. Before installing this chart — or enabling the setup job — the following server parameters must be in place. `pg_stat_statements` can't be created without `shared_preload_libraries`, and that parameter requires a **restart**, so nothing running inside your Kubernetes cluster can do this for you.
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`shared_preload_libraries`</td>
+      <td>`pg_stat_statements`</td>
+    </tr>
+    <tr>
+      <td>`pg_stat_statements.track`</td>
+      <td>`ALL`</td>
+    </tr>
+    <tr>
+      <td>`pg_stat_statements.max`</td>
+      <td>`10000`</td>
+    </tr>
+    <tr>
+      <td>`pg_stat_statements.save`</td>
+      <td>`on`</td>
+    </tr>
+    <tr>
+      <td>`track_activity_query_size`</td>
+      <td>`4096`</td>
+    </tr>
+    <tr>
+      <td>`track_functions`</td>
+      <td>`all`</td>
+    </tr>
+  </tbody>
+</table>
+
+* **Self-hosted**: set these in `postgresql.conf`, then restart PostgreSQL. Some distributions need the `postgresql-contrib` package installed for `pg_stat_statements` to be available.
+* **AWS RDS or Aurora**: set these in the DB **parameter group**, not a config file. `track_activity_query_size` and `pg_stat_statements.max` are static parameters — apply them with `apply_method: pending-reboot`, then reboot the instance. Applying them immediately fails with `InvalidParameterCombination`. For Aurora, the parameter-group family name must match your engine's major version exactly, for example `aurora-postgresql16`.
+
+</Step>
+
+<Step>
+
+### Prerequisites [#helm-prerequisites]
+
+* Valid New Relic [license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key).
+* Helm 3.0 or later, and `kubectl` configured to access your Kubernetes cluster.
+* Network connectivity from your Kubernetes cluster to the PostgreSQL host (or RDS endpoint) and port:
+  * Self-hosted: a routed path to the PostgreSQL host (VPN, peering, or shared network), DNS resolution if it's a hostname, and the PostgreSQL-side `pg_hba.conf` and firewall must allow the connection's actual source IP (which may be a NAT gateway, not the pod IP itself).
+  * AWS RDS: VPC peering, a transit gateway, or shared-VPC placement with the RDS instance, and the RDS security group must allow the PostgreSQL port (`5432` by default) from the cluster's egress source.
+* Either a monitoring role you've already created with its per-database grants, or PostgreSQL admin credentials so the chart's setup job can create them for you. See [Configure monitoring credentials](#helm-credentials) below.
+
+</Step>
+
+<Step>
+
+### Create the namespace [#helm-namespace]
+
+Create the namespace you'll install into. It must exist before you create any secrets in the next step, since `helm install --create-namespace` only creates the namespace during the final install step:
+
+```bash
+kubectl create namespace newrelic
+```
+
+<Callout variant="tip">
+
+  Set it as the default namespace for your current `kubectl` context so you don't need to pass `-n` on every command below:
+
+  ```bash
+  kubectl config set-context --current --namespace=newrelic
+  ```
+
+</Callout>
+
+</Step>
+
+<Step>
+
+### Configure monitoring credentials [#helm-credentials]
+
+Choose how the chart should get the PostgreSQL monitoring role's credentials:
+
+<CollapserGroup>
+
+<Collapser
+  id="helm-creds-inline"
+  title="Plain username and password"
+>
+
+With this method there's no setup job, so nothing here creates the monitoring role for you. Before installing the chart, create it yourself as a superuser. Run this once at the cluster level:
+
+```sql
+CREATE USER newrelic WITH LOGIN PASSWORD '<password>';
+ALTER ROLE newrelic INHERIT;   -- required on PG15+, a no-op on PG14
+```
+
+Then run this in **every** database you plan to list in `postgresql.databases`:
+
+```sql
+CREATE SCHEMA IF NOT EXISTS otel;
+GRANT USAGE ON SCHEMA otel TO newrelic;
+GRANT USAGE ON SCHEMA public TO newrelic;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO newrelic;
+GRANT pg_monitor TO newrelic;
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+```
+
+For more detail, refer to the **Configure database user and grants** step for [self-hosted PostgreSQL](/docs/opentelemetry/database/postgresql/hosted/#database-user) or [PostgreSQL on RDS](/docs/opentelemetry/database/postgresql/rds/#database-user).
+
+You'll set the monitoring username and password directly in `values.yaml` in the next step.
+
+</Collapser>
+
+<Collapser
+  id="helm-creds-secret"
+  title="Secret-based credentials"
+>
+
+With this method, the chart's setup job creates the monitoring role for you and, for every database in `postgresql.databases`, creates the `otel` schema, grants `USAGE`/`SELECT`/`pg_monitor`, and creates the `pg_stat_statements` extension.
+
+1. Create a secret with the monitoring username and password. This is the identity the setup job creates and the collector connects with:
+
+    ```bash
+    kubectl create secret generic postgres-monitor-creds \
+      --from-literal=username=<MONITORING_USERNAME> \
+      --from-literal=password='<MONITORING_PASSWORD>' \
+      -n newrelic
+    ```
+
+2. The setup job only accepts admin credentials via a Kubernetes secret (no plaintext username/password in `values.yaml`). This credential must be a superuser (self-hosted) or an `rds_superuser` equivalent (RDS), since it needs `CREATE USER`, `CREATE SCHEMA`, and `CREATE EXTENSION`:
+
+    ```bash
+    kubectl create secret generic postgres-admin-creds \
+      --from-literal=username=<ADMIN_USERNAME> \
+      --from-literal=password='<ADMIN_PASSWORD>' \
+      -n newrelic
+    ```
+
+</Collapser>
+
+</CollapserGroup>
+
+</Step>
+
+<Step>
+
+### Configure the Helm values [#helm-configure]
+
+Set `postgresql.topology` to match your environment:
+
+<table>
+  <thead>
+    <tr>
+      <th>Value</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`self-hosted`</td>
+      <td>Self-hosted PostgreSQL, reached over the network.</td>
+    </tr>
+    <tr>
+      <td>`rds`</td>
+      <td>PostgreSQL or Aurora on AWS RDS.</td>
+    </tr>
+  </tbody>
+</table>
+
+`postgresql.databases` is a **required, non-empty list**. Unlike MySQL or SQL Server, PostgreSQL has no monitor-every-database mode — a connection targets one database at a time, so the receiver has to be told which ones to scrape.
+
+Use the `values.yaml` that matches the credential method you chose in the previous step:
+
+<CollapserGroup>
+
+<Collapser
+  id="helm-values-inline"
+  title="Plain username and password"
+>
+
+```yaml
+licenseKey: <YOUR_LICENSE_KEY>
+otlpEndpoint: otlp.nr-data.net:4317
+
+postgresql:
+  topology: <self-hosted|rds>
+  server: <YOUR_DB_HOST>
+  port: <YOUR_DB_PORT>
+  username: <YOUR_MONITORING_USERNAME>
+  password: <YOUR_MONITORING_PASSWORD>
+  databases:
+    - <YOUR_DATABASE>
+    - <ANOTHER_DATABASE>
+
+# setupJob.postgresAdmin only ever accepts existingSecret
+# (no plaintext username/password), and since this
+# credential needs CREATE USER, CREATE SCHEMA, and CREATE
+# EXTENSION, the setup job is only ever enabled for
+# Secret-based credentials. Create the monitoring role and
+# its per-database grants yourself before installing.
+setupJob:
+  enabled: false
+```
+
+</Collapser>
+
+<Collapser
+  id="helm-values-secret"
+  title="Secret-based credentials"
+>
+
+```yaml
+licenseKey: <YOUR_LICENSE_KEY>
+otlpEndpoint: otlp.nr-data.net:4317
+
+postgresql:
+  topology: <self-hosted|rds>
+  server: <YOUR_DB_HOST>
+  port: <YOUR_DB_PORT>
+  existingSecret: postgres-monitor-creds
+  databases:
+    - <YOUR_DATABASE>
+    - <ANOTHER_DATABASE>
+
+setupJob:
+  enabled: true
+  image:
+    # -- psql-capable image. No default: the official postgres
+    # image bundles psql and is a reasonable choice.
+    repository: postgres
+    tag: "16"
+    pullPolicy: IfNotPresent
+  postgresAdmin:
+    existingSecret: postgres-admin-creds
+  # -- Also creates the otel.explain_statement SECURITY DEFINER
+  # function, so the receiver can EXPLAIN write/locking queries.
+  enableExplainPermissions: false
+  # -- Also creates the pgvector extension in each database.
+  enablePgvector: false
+```
+
+</Collapser>
+
+</CollapserGroup>
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`licenseKey`</td>
+      <td>Your New Relic license key.</td>
+    </tr>
+    <tr>
+      <td>`otlpEndpoint`</td>
+      <td>Your region's OTLP/gRPC endpoint, as a bare `host:port` with **no scheme**: `otlp.nr-data.net:4317` (US) or `otlp.eu01.nr-data.net:4317` (EU). For more information, refer to [New Relic OTLP endpoints documentation](/docs/opentelemetry/best-practices/opentelemetry-otlp/).</td>
+    </tr>
+    <tr>
+      <td>`postgresql.server` / `postgresql.port`</td>
+      <td>Your PostgreSQL host (or RDS endpoint) and port, reachable from the cluster.</td>
+    </tr>
+    <tr>
+      <td>`postgresql.databases`</td>
+      <td>**Required, non-empty list** of databases to monitor.</td>
+    </tr>
+    <tr>
+      <td>`postgresql.excludeDatabases`</td>
+      <td>Databases excluded from cluster-wide top-query and query-sample scans. Defaults to `[rdsadmin]`, and is only rendered when `topology` is `rds` — on RDS the monitoring user can never reach `rdsadmin`, so excluding it avoids permission errors.</td>
+    </tr>
+    <tr>
+      <td>`setupJob.image.repository` / `setupJob.image.tag`</td>
+      <td>A `psql`-capable image used by the setup job. The chart ships **no default**, so you must supply one when the setup job is enabled. The official `postgres` image bundles `psql` and is a reasonable choice.</td>
+    </tr>
+    <tr>
+      <td>`setupJob.enableExplainPermissions`</td>
+      <td>Optional. Also creates the `otel.explain_statement` `SECURITY DEFINER` function and grants `EXECUTE` on it, letting the receiver run `EXPLAIN` against locking and write queries without holding write grants. Leaving it `false` is safe — the receiver falls back to inline `EXPLAIN`, so those statements simply don't get query plans.</td>
+    </tr>
+    <tr>
+      <td>`setupJob.enablePgvector`</td>
+      <td>Optional. Also creates the `vector` extension in each monitored database, for vector metrics. The `l1`, `hamming`, and `jaccard` distance functions need pgvector 0.7.0 or later.</td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="tip">
+  You usually don't need to set `postgresql.topQueryCollection.explainFunctionName`. The receiver's own default is already `otel.explain_statement` — the exact function `setupJob.enableExplainPermissions` creates — and the chart omits the key when it's empty, so the two line up with no extra configuration. Set it only to point the receiver at a differently-named function.
+</Callout>
+
+<Callout variant="tip">
+
+  See the chart's [values.yaml](https://github.com/newrelic/helm-charts/blob/master/charts/postgresql-otel/values.yaml) for all available configuration options, including `postgresql.collectionInterval`, the `metrics` toggles, the `topQueryCollection`/`querySampleCollection` blocks, and the `additionalReceiverConfig` escape hatch.
+
+</Callout>
+
+</Step>
+
+<Step>
+
+### Install the Helm chart [#helm-install]
+
+1. Add the New Relic Helm repository:
+
+    ```bash
+    helm repo add newrelic https://helm-charts.newrelic.com
+    helm repo update
+    ```
+
+2. Install the chart using your `values.yaml` file:
+
+    ```bash
+    helm upgrade --install postgresql-otel newrelic/postgresql-otel \
+      -n newrelic \
+      --create-namespace \
+      -f values.yaml
+    ```
+
+</Step>
+
+<Step>
+
+### Verify the installation [#helm-verify]
+
+1. Check that the setup job completed (if enabled) and the collector pod is running:
+
+    ```bash
+    kubectl get jobs,pods -n newrelic --watch
+    ```
+
+2. Run this query in the [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder/) to confirm data is arriving:
+
+    ```sql
+    SELECT count(*) FROM Metric
+    WHERE metricName LIKE 'postgresql.%'
+    AND instrumentation.provider = 'opentelemetry'
+    SINCE 10 minutes ago
+    ```
+
+</Step>
+
+<Step>
+
+## Find and use your data [#find]
+
+Once your data is being collected, you can access comprehensive PostgreSQL database monitoring through the New Relic UI.
+
+To find your PostgreSQL database entity in New Relic:
+
+1. Go to <DNT>**[one.newrelic.com](https://one.newrelic.com) > All capabilities > Databases**</DNT>.
+2. From the **<DNT>Entity type</DNT>** dropdown, select <DNT>**PostgreSQL instance**</DNT>, then click <DNT>**Apply**</DNT>.
+3. Select your PostgreSQL database from the list of entities.
+
+</Step>
+
+</Steps>
+
+## Related documentation [#related]
+
+<DocTiles>
+  <DocTile title="Introduction to PostgreSQL monitoring with NRDOT" path="/docs/opentelemetry/database/postgresql/introduction">Learn about all the available installation methods for PostgreSQL monitoring with New Relic.</DocTile>
+  <DocTile title="CLI install" path="/docs/opentelemetry/database/postgresql/cli">Learn how to install and configure PostgreSQL monitoring with a single New Relic CLI command.</DocTile>
+  <DocTile title="Ansible install" path="/docs/opentelemetry/database/postgresql/ansible">Learn how to install and configure PostgreSQL monitoring at scale with the newrelic.newrelic_install Ansible role.</DocTile>
+  <DocTile title="Chef install" path="/docs/opentelemetry/database/postgresql/chef">Learn how to install and configure PostgreSQL monitoring at scale with the newrelic-install Chef cookbook.</DocTile>
+</DocTiles>

--- a/src/content/docs/opentelemetry/database/postgresql/introduction.mdx
+++ b/src/content/docs/opentelemetry/database/postgresql/introduction.mdx
@@ -26,8 +26,13 @@ This NRDOT-based approach complements our existing On-Host Integration (OHI) by 
 
 You can install NRDOT Collector for PostgreSQL monitoring in following ways:
 
-* [Self-hosted setup](/docs/opentelemetry/database/postgresql/hosted)
-* [AWS RDS or Aurora setup](/docs/opentelemetry/database/postgresql/rds)
+* **Manual install**: Set up the collector yourself on your own infrastructure
+  * [Self-hosted setup](/docs/opentelemetry/database/postgresql/hosted)
+  * [AWS RDS or Aurora setup](/docs/opentelemetry/database/postgresql/rds)
+* **[New Relic CLI](/docs/opentelemetry/database/postgresql/cli)**: Install and configure the collector with a single command
+* **[Ansible](/docs/opentelemetry/database/postgresql/ansible)**: Install and configure the collector at scale using the `newrelic.newrelic_install` Ansible role
+* **[Chef](/docs/opentelemetry/database/postgresql/chef)**: Install and configure the collector at scale using the `newrelic-install` Chef cookbook
+* **[Helm chart](/docs/opentelemetry/database/postgresql/helm)**: Install and configure PostgreSQL monitoring on Kubernetes using the `postgresql-otel` Helm chart
 
 
 ## Installation at a glance [#glance]
@@ -62,6 +67,8 @@ Choose your installation path based on your infrastructure:
 
 - **[Self-hosted PostgreSQL](/docs/opentelemetry/database/postgresql/hosted)**
 - **[RDS PostgreSQL monitoring](/docs/opentelemetry/database/postgresql/rds)** 
+
+To automate the install instead, use the [New Relic CLI](/docs/opentelemetry/database/postgresql/cli), [Ansible](/docs/opentelemetry/database/postgresql/ansible), or [Chef](/docs/opentelemetry/database/postgresql/chef). To monitor PostgreSQL from Kubernetes, use the [Helm chart](/docs/opentelemetry/database/postgresql/helm).
 
 
 </Step>
@@ -103,5 +110,9 @@ To find your PostgreSQL database entity in New Relic:
 <DocTiles>
   <DocTile title="Instrumentation in self-hosted environments" path="/docs/opentelemetry/database/postgresql/hosted">Learn how to set up PostgreSQL monitoring in self-hosted environments with New Relic.</DocTile>
   <DocTile title="Instrumentation in RDS environments" path="/docs/opentelemetry/database/postgresql/rds">Learn how to set up PostgreSQL monitoring in RDS environments with New Relic.</DocTile>
+  <DocTile title="CLI install" path="/docs/opentelemetry/database/postgresql/cli">Learn how to install and configure PostgreSQL monitoring with a single New Relic CLI command.</DocTile>
+  <DocTile title="Ansible install" path="/docs/opentelemetry/database/postgresql/ansible">Learn how to install and configure PostgreSQL monitoring at scale with the newrelic.newrelic_install Ansible role.</DocTile>
+  <DocTile title="Chef install" path="/docs/opentelemetry/database/postgresql/chef">Learn how to install and configure PostgreSQL monitoring at scale with the newrelic-install Chef cookbook.</DocTile>
+  <DocTile title="Helm chart install" path="/docs/opentelemetry/database/postgresql/helm">Learn how to install and configure PostgreSQL monitoring on Kubernetes with the postgresql-otel Helm chart.</DocTile>
   <DocTile title="Metrics reference" path="/docs/opentelemetry/database/postgresql/metrics-reference">Learn about the available metrics collected by the NRDOT Collector.</DocTile>
 </DocTiles>


### PR DESCRIPTION
## Summary
- Adds four manual install methods to the Oracle Database NRDOT monitoring doc, alongside the existing Guided/On-host/RDS/ADB tabs: **CLI**, **Ansible**, **Chef**, and **Helm chart**.
- CLI/Ansible/Chef install the collector, create the monitoring database user, and configure the collector via the `newrelic install`/`newrelic.newrelic_install` role/`newrelic-install` cookbook, matching the existing on-host and RDS variable tables.
- Helm chart tab documents installing the `oracle-otel` chart (`helm-charts.newrelic.com`) on Kubernetes, covering:
  - Two credential paths: plain username/password in `values.yaml`, or Kubernetes Secret-based credentials that let the chart's setup job create the monitoring user for you.
  - The required `setupJob.image` override (no default — pulling from `container-registry.oracle.com` requires accepting Oracle's license terms).
  - `oracle.topology` values (`cdb`/`pdb`/`rds`/`adb`), install command, and a verification query.