### PR TITLE
feat: Add Linkerd Otel instrumentation docs

### DIFF
--- a/src/content/docs/opentelemetry/integrations/linkerd/find-and-query-your-data.mdx
+++ b/src/content/docs/opentelemetry/integrations/linkerd/find-and-query-your-data.mdx
@@ -1,0 +1,163 @@
+---
+title: 'Find and query your Linkerd data'
+metaDescription: 'Access Linkerd metrics, traces, and logs in New Relic — navigate to your Linkerd entity, explore dashboards, and run NRQL queries.'
+freshnessValidatedDate: never
+---
+
+After setting up the OpenTelemetry Collector for Linkerd, your mesh telemetry flows into New Relic as `Metric`, `Span`, and `Log` events scoped under your Linkerd entity.
+
+## Find your Linkerd entity [#find-entity]
+
+1. Go to [one.newrelic.com](https://one.newrelic.com) and select **Entity Explorer**.
+2. Search for your cluster name.
+3. Select your Linkerd entity to open the built-in dashboard.
+
+The built-in dashboard covers request rate, latency p50/p95/p99, success rate, TCP connections, mTLS certificate status, control plane health, and meshed pod inventory.
+
+## Example NRQL queries [#queries]
+
+Replace `<YOUR_CLUSTER>` with your actual cluster name in each query.
+
+### Request rate per service
+
+```sql
+SELECT rate(sum(request_total), 1 minute) AS 'Req/min'
+FROM Metric
+WHERE k8s.cluster.name = '<YOUR_CLUSTER>'
+  AND linkerd_control_plane_component IS NULL
+FACET k8s.deployment.name
+SINCE 30 minutes ago
+TIMESERIES
+```
+
+### Latency p99 per service
+
+```sql
+SELECT histogram(response_latency_ms, width: 50, slide_by: 10)
+FROM Metric
+WHERE k8s.cluster.name = '<YOUR_CLUSTER>'
+  AND linkerd_control_plane_component IS NULL
+FACET k8s.deployment.name
+SINCE 30 minutes ago
+```
+
+### HTTP success rate
+
+```sql
+SELECT
+  sum(response_total) AS 'Total responses',
+  filter(sum(response_total), WHERE classification = 'success') / sum(response_total) * 100 AS 'Success %'
+FROM Metric
+WHERE k8s.cluster.name = '<YOUR_CLUSTER>'
+FACET k8s.deployment.name
+SINCE 30 minutes ago
+```
+
+### mTLS certificate expiry
+
+```sql
+SELECT latest(identity_cert_expiration_timestamp_seconds) AS 'Cert expires (epoch)'
+FROM Metric
+WHERE k8s.cluster.name = '<YOUR_CLUSTER>'
+FACET k8s.deployment.name
+SINCE 10 minutes ago
+```
+
+### Control plane queue depth
+
+```sql
+SELECT latest(control_plane_queue_length) AS 'Queue depth'
+FROM Metric
+WHERE k8s.cluster.name = '<YOUR_CLUSTER>'
+  AND linkerd_control_plane_component IS NOT NULL
+FACET linkerd_control_plane_component
+SINCE 10 minutes ago
+```
+
+### TCP open connections
+
+```sql
+SELECT rate(sum(tcp_open_connections), 1 second) AS 'TCP connections'
+FROM Metric
+WHERE k8s.cluster.name = '<YOUR_CLUSTER>'
+FACET k8s.deployment.name
+SINCE 30 minutes ago
+TIMESERIES
+```
+
+### Distributed traces (APM path only)
+
+```sql
+SELECT count(*) FROM Span
+WHERE k8s.cluster.name = '<YOUR_CLUSTER>'
+FACET service.name
+SINCE 30 minutes ago
+```
+
+```sql
+-- Verify proxy spans are being collected with Linkerd attributes
+SELECT count(*) FROM Span
+WHERE k8s.cluster.name = '<YOUR_CLUSTER>'
+  AND linkerd_control_plane_component IS NOT NULL
+FACET service.name
+SINCE 10 minutes ago
+```
+
+If this returns 0, the `transform/linkerd_component_inject` processor is not running or `linkerd_control_plane_ns` is missing from spans. See [troubleshooting](/docs/opentelemetry/integrations/linkerd/linkerd-otel-setup/#troubleshooting) for remediation steps.
+
+## Access the Linkerd dashboard [#dashboard]
+
+Navigate to **Entity Explorer**, search for your cluster name, and select the Linkerd entity to open the built-in dashboard. It includes:
+
+| Section | Panels |
+|---|---|
+| Top-line | TCP Connections, Requests Served by Proxies |
+| Traffic | Inbound Rate, Outbound Rate |
+| Health | Success Rate, Error Rate, HTTP Status Codes |
+| Latency | Request Latency p50/p95/p99, Outbound Latency p99 |
+| Security | mTLS Certificate Expiry, Cert Refresh Rate |
+| Control Plane | Authorization Policy, Queue Depth, CP Request Rate |
+| Topology | Proxy Memory Usage, Operations by Service |
+| Inventory | Meshed Pods |
+
+## Data not appearing? [#troubleshoot-data]
+
+<CollapserGroup>
+
+  <Collapser id="no-entity" title="Linkerd entity not showing up">
+
+Verify that Linkerd proxy metrics are reaching New Relic:
+
+```sql
+SELECT count(*) FROM Metric
+WHERE linkerd_control_plane_ns IS NOT NULL
+  AND k8s.cluster.name = '<YOUR_CLUSTER>'
+SINCE 5 minutes ago
+```
+
+If this returns 0, check that the collector pods are running and the Prometheus scrape jobs in the collector config are targeting the correct namespaces.
+
+  </Collapser>
+
+  <Collapser id="no-deployment-entities" title="Workload entities missing">
+
+Workload entities require kube-state-metrics. Verify it is sending data:
+
+```sql
+SELECT uniques(k8s.deployment.name)
+FROM Metric
+WHERE metricName LIKE 'kube_deployment%'
+  AND k8s.cluster.name = '<YOUR_CLUSTER>'
+SINCE 10 minutes ago
+```
+
+If empty, confirm kube-state-metrics is running and the scrape target in the collector config points to the correct namespace and service name.
+
+  </Collapser>
+
+</CollapserGroup>
+
+## Next steps [#next-steps]
+
+- [Linkerd metrics reference](/docs/opentelemetry/integrations/linkerd/linkerd-otel-metrics-reference/) — full list of metrics and resource attributes
+- [Linkerd OpenTelemetry monitoring overview](/docs/opentelemetry/integrations/linkerd/linkerd-otel-overview/) — back to overview

--- a/src/content/docs/opentelemetry/integrations/linkerd/linkerd-otel-metrics-reference.mdx
+++ b/src/content/docs/opentelemetry/integrations/linkerd/linkerd-otel-metrics-reference.mdx
@@ -1,0 +1,297 @@
+---
+title: 'Linkerd OpenTelemetry metrics reference'
+metaDescription: 'Complete reference of Linkerd proxy and control plane metrics collected by the OpenTelemetry Collector Prometheus receiver, with resource attributes.'
+freshnessValidatedDate: never
+---
+
+The Linkerd OTel integration collects metrics by scraping the Linkerd proxy admin port (`:4191`) and control plane pods using the OpenTelemetry Collector's [Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver). All metrics arrive in New Relic as `eventType = Metric` with `instrumentation.provider = opentelemetry`.
+
+## HTTP traffic metrics [#http-metrics]
+
+Emitted by every meshed pod's `linkerd-proxy` sidecar.
+
+<table>
+  <thead>
+    <tr>
+      <th>Metric name</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`request_total`</td>
+      <td>Counter</td>
+      <td>Total HTTP requests received (inbound) or sent (outbound). Facet by `direction`, `target_namespace`, `target_deployment`.</td>
+    </tr>
+    <tr>
+      <td>`response_total`</td>
+      <td>Counter</td>
+      <td>Total HTTP responses. Labels: `classification` (`success`/`failure`), `status_code`.</td>
+    </tr>
+    <tr>
+      <td>`response_latency_ms_bucket`</td>
+      <td>Histogram</td>
+      <td>HTTP response latency in milliseconds. Use `percentile()` for p50/p95/p99.</td>
+    </tr>
+    <tr>
+      <td>`response_latency_ms_count`</td>
+      <td>Counter</td>
+      <td>Count of latency observations (denominator for average latency).</td>
+    </tr>
+    <tr>
+      <td>`response_latency_ms_sum`</td>
+      <td>Counter</td>
+      <td>Sum of latency observations in milliseconds.</td>
+    </tr>
+    <tr>
+      <td>`route_request_total`</td>
+      <td>Counter</td>
+      <td>Per-route request count. Requires HTTPRoute policies to be configured.</td>
+    </tr>
+    <tr>
+      <td>`route_response_total`</td>
+      <td>Counter</td>
+      <td>Per-route response count with `classification` label. Requires HTTPRoute policies.</td>
+    </tr>
+    <tr>
+      <td>`route_response_latency_ms_bucket`</td>
+      <td>Histogram</td>
+      <td>Per-route response latency. Requires HTTPRoute policies.</td>
+    </tr>
+  </tbody>
+</table>
+
+## TCP metrics [#tcp-metrics]
+
+<table>
+  <thead>
+    <tr>
+      <th>Metric name</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`tcp_open_connections`</td>
+      <td>Gauge</td>
+      <td>Current open TCP connections, by `direction` (inbound/outbound).</td>
+    </tr>
+    <tr>
+      <td>`tcp_open_total`</td>
+      <td>Counter</td>
+      <td>Total TCP connections opened.</td>
+    </tr>
+    <tr>
+      <td>`tcp_close_total`</td>
+      <td>Counter</td>
+      <td>Total TCP connections closed. Labels: `classification` (`success`/`failure`).</td>
+    </tr>
+    <tr>
+      <td>`tcp_read_bytes_total`</td>
+      <td>Counter</td>
+      <td>Total bytes read from TCP connections.</td>
+    </tr>
+    <tr>
+      <td>`tcp_write_bytes_total`</td>
+      <td>Counter</td>
+      <td>Total bytes written to TCP connections.</td>
+    </tr>
+    <tr>
+      <td>`tcp_connection_duration_ms_bucket`</td>
+      <td>Histogram</td>
+      <td>TCP connection lifetime in milliseconds.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Authorization metrics [#authz-metrics]
+
+<table>
+  <thead>
+    <tr>
+      <th>Metric name</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`inbound_http_authz_allow_total`</td>
+      <td>Counter</td>
+      <td>HTTP requests allowed by authorization policy.</td>
+    </tr>
+    <tr>
+      <td>`inbound_http_authz_deny_total`</td>
+      <td>Counter</td>
+      <td>HTTP requests denied by authorization policy.</td>
+    </tr>
+    <tr>
+      <td>`inbound_tcp_authz_allow_total`</td>
+      <td>Counter</td>
+      <td>TCP connections allowed by authorization policy.</td>
+    </tr>
+    <tr>
+      <td>`inbound_tcp_authz_deny_total`</td>
+      <td>Counter</td>
+      <td>TCP connections denied by authorization policy.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Identity and mTLS metrics [#mtls-metrics]
+
+<table>
+  <thead>
+    <tr>
+      <th>Metric name</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`identity_cert_expiration_timestamp_seconds`</td>
+      <td>Gauge</td>
+      <td>Unix timestamp when the proxy's mTLS certificate expires. Alert when this is less than 24 hours from now.</td>
+    </tr>
+    <tr>
+      <td>`identity_cert_refresh_count`</td>
+      <td>Counter</td>
+      <td>Number of mTLS certificate refreshes. Sudden drops indicate identity service issues.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Control plane metrics [#control-plane-metrics]
+
+Emitted by Linkerd control plane pods (`destination`, `identity`, `proxy-injector`).
+
+<table>
+  <thead>
+    <tr>
+      <th>Metric name</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`control_plane_live_endpoints`</td>
+      <td>Gauge</td>
+      <td>Number of live endpoints known to the destination controller. Low values indicate service discovery issues.</td>
+    </tr>
+    <tr>
+      <td>`control_plane_queue_length`</td>
+      <td>Gauge</td>
+      <td>Pending work items in the destination controller queue. High values indicate overload.</td>
+    </tr>
+    <tr>
+      <td>`control_plane_updates_queue_depth`</td>
+      <td>Gauge</td>
+      <td>Depth of the endpoint update queue.</td>
+    </tr>
+    <tr>
+      <td>`proxy_injector_cert_rotation_total`</td>
+      <td>Counter</td>
+      <td>Proxy-injector webhook certificate rotations.</td>
+    </tr>
+    <tr>
+      <td>`proxy_injector_injection_total`</td>
+      <td>Counter</td>
+      <td>Total proxy injections. Labels: `injected` (true/false), `reason`.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Process metrics [#process-metrics]
+
+Standard Prometheus process metrics emitted by each proxy.
+
+<table>
+  <thead>
+    <tr>
+      <th>Metric name</th>
+      <th>Type</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`process_cpu_seconds_total`</td>
+      <td>Counter</td>
+      <td>Total user + system CPU time consumed by the proxy process.</td>
+    </tr>
+    <tr>
+      <td>`process_resident_memory_bytes`</td>
+      <td>Gauge</td>
+      <td>Resident set size (RSS) of the proxy process in bytes.</td>
+    </tr>
+    <tr>
+      <td>`process_virtual_memory_bytes`</td>
+      <td>Gauge</td>
+      <td>Virtual memory size of the proxy process.</td>
+    </tr>
+    <tr>
+      <td>`process_open_fds`</td>
+      <td>Gauge</td>
+      <td>Number of open file descriptors. High values can indicate connection leak.</td>
+    </tr>
+    <tr>
+      <td>`process_uptime_seconds_total`</td>
+      <td>Counter</td>
+      <td>Seconds since the proxy process started.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Default-off metrics [#default-off]
+
+The following metric groups are disabled by default in the optimized collector config to reduce ingest volume. Remove the corresponding condition from `filter/drop_unused` to re-enable.
+
+<Callout variant="tip">
+  These groups are off by default because they provide no operational value in steady state. Enable them only when actively debugging the specific issue described.
+</Callout>
+
+| Group | Metrics | Re-enable when |
+|---|---|---|
+| Version/build info | `rustls_info`, `proxy_build_info` | Never |
+| Prometheus scraper | `scrape_series_added`, `scrape_duration_seconds`, `scrape_samples_*` | Initial collector setup |
+| Proxy stack internals | `stack_poll_total`, `stack_create_total`, `stack_drop_total`, `stack_poll_total_ms` | Proxy CPU/overload investigation |
+| Tokio async runtime | `tokio_rt_*` | Proxy CPU starvation |
+| HTTP frame sizes | `*_http_*_frame_size_bytes`, `outbound_http_route_request_frame_size_bytes` | Large-payload debugging |
+| TCP protocol detection | `inbound_tcp_detect_http_duration_seconds`, `outbound_tcp_detect_http_duration_seconds` | Protocol detection failures |
+| TCP balancer queue | `outbound_tcp_balancer_queue_*` | Outbound TCP backpressure |
+
+## Resource attributes [#resource-attributes]
+
+These attributes are added to every metric by the OTel Collector and can be used as FACET or WHERE filters.
+
+### Common attributes
+
+| Attribute | Description |
+|---|---|
+| `instrumentation.provider` | Always `opentelemetry` |
+| `k8s.cluster.name` | Kubernetes cluster name, set via `OTEL_RESOURCE_ATTRIBUTES` env var |
+| `k8s.namespace.name` | Namespace of the meshed pod |
+| `k8s.pod.name` | Name of the meshed pod |
+| `k8s.deployment.name` | Deployment that owns the pod (derived from pod name if not emitted natively) |
+| `k8s.node.name` | Kubernetes node running the pod |
+
+### Linkerd-specific attributes
+
+| Attribute | Description |
+|---|---|
+| `linkerd_control_plane_ns` | Namespace where Linkerd control plane is installed (e.g. `linkerd`). Present on all meshed pods. Used as the entity synthesis discriminator. |
+| `linkerd_control_plane_component` | Control plane component name (`destination`, `identity`, `proxy-injector`). |
+
+### kube-state-metrics attributes
+
+These attributes are added only to metrics scraped from kube-state-metrics.
+
+| Attribute | Description |
+|---|---|
+| `k8s.deployment.name` | Deployment name from KSM labels |
+| `k8s.pod.name` | Pod name from KSM labels |
+| `k8s.node.name` | Node name from KSM labels |

--- a/src/content/docs/opentelemetry/integrations/linkerd/linkerd-otel-overview.mdx
+++ b/src/content/docs/opentelemetry/integrations/linkerd/linkerd-otel-overview.mdx
@@ -1,0 +1,49 @@
+---
+title: 'Linkerd OpenTelemetry monitoring overview'
+metaDescription: 'Learn about monitoring Linkerd service mesh with OpenTelemetry: mesh-level metrics, distributed traces, logs, and APM relationship visibility in New Relic.'
+freshnessValidatedDate: never
+---
+
+Get complete visibility into your [Linkerd](https://linkerd.io/) service mesh with OpenTelemetry. This integration scrapes Linkerd proxy and control plane metrics via the OpenTelemetry Collector's [Prometheus receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver), and optionally collects distributed traces (Linkerd 2.19+) and container logs, all sent to New Relic.
+
+## Why monitor Linkerd with OpenTelemetry? [#why-monitor]
+
+Linkerd acts as an invisible layer between every service in your cluster. Without mesh-level observability you can see what services do but not how they communicate. Retries, mTLS failures, slow upstreams, and authorization denials are invisible at the application layer.
+
+### Key benefits
+
+- **Mesh-level golden signals**: Request rate, latency p50/p95/p99, success rate, and TCP connections per workload, collected automatically for every meshed service without any application code changes.
+- **mTLS and security visibility**: Certificate expiry countdown, rotation rate, and authorization policy allow/deny counts in one place.
+- **Control plane health**: Queue depth, live endpoint counts, certificate issuance rate, and proxy-injector activity for the Linkerd control plane itself.
+- **APM relationship visibility**: When distributed tracing is enabled (Linkerd 2.19+), Linkerd proxy spans are synthesized to a first-class Linkerd entity alongside your APM services, with no separate tracing backend required.
+- **Zero code changes**: Every meshed pod's proxy sidecar exposes metrics on `:4191`. The OTel Collector scrapes them automatically.
+
+### Use case
+
+Linkerd monitoring is essential for platform and SRE teams running Kubernetes-native microservices. Know which upstream service is causing your latency spike, detect when mTLS certificates are about to expire, understand retry storms, and correlate control-plane load with application performance, all from a single New Relic entity.
+
+## What you get [#what-you-get]
+
+| Telemetry | What it covers |
+|---|---|
+| **Metrics** | Per-workload request rate, latency, success rate, TCP connections, mTLS stats, control plane health |
+| **Traces** (optional, 2.19+) | Distributed traces from Linkerd proxy spans + app spans in the same waterfall |
+| **Logs** | `linkerd-proxy` container logs attached to the same entity |
+
+## Available metrics [#metrics]
+
+The integration collects all metrics exposed by the Linkerd proxy admin port (`:4191`) and the Linkerd control plane pods. Key metric categories:
+
+- **HTTP traffic**: `request_total`, `response_total`, `response_latency_ms_bucket`
+- **TCP**: `tcp_open_connections`, `tcp_read_bytes_total`, `tcp_write_bytes_total`
+- **mTLS**: `identity_cert_expiration_timestamp_seconds`, `identity_cert_refresh_count`
+- **Authorization**: `inbound_http_authz_allow_total`, `inbound_http_authz_deny_total`
+- **Control plane**: `control_plane_live_endpoints`, `control_plane_queue_length`, `proxy_injector_cert_rotation_total`
+
+For a complete list, see [Linkerd OpenTelemetry metrics reference](/docs/opentelemetry/integrations/linkerd/linkerd-otel-metrics-reference/).
+
+## Next steps [#next-steps]
+
+- [Monitor Linkerd on Kubernetes with OpenTelemetry](/docs/opentelemetry/integrations/linkerd/linkerd-otel-setup/): step-by-step setup guide
+- [Find and query your Linkerd data](/docs/opentelemetry/integrations/linkerd/find-and-query-your-data/): NRQL queries and dashboard navigation
+- [Linkerd metrics reference](/docs/opentelemetry/integrations/linkerd/linkerd-otel-metrics-reference/): complete metrics and attributes reference

--- a/src/content/docs/opentelemetry/integrations/linkerd/linkerd-otel-setup.mdx
+++ b/src/content/docs/opentelemetry/integrations/linkerd/linkerd-otel-setup.mdx
@@ -1,0 +1,563 @@
+---
+title: 'Set up Linkerd monitoring with OpenTelemetry'
+metaDescription: 'Step-by-step guide to send Linkerd service mesh metrics, traces, and logs to New Relic using the OpenTelemetry Collector.'
+freshnessValidatedDate: never
+---
+
+This guide walks you through deploying an OpenTelemetry Collector that scrapes Linkerd proxy and control plane metrics, collects container logs, and optionally receives distributed traces, all sent to New Relic.
+
+| Setup path | What you get | Code changes? |
+|---|---|---|
+| **Basic** | Mesh metrics (request rate, latency, error rate, mTLS, topology) for every meshed service | None |
+| **APM** (optional) | Everything in Basic + distributed traces, per-endpoint breakdown, stack traces | Add OTel agent to app pods |
+
+## Before you begin [#prerequisites]
+
+- Linkerd installed and healthy in your cluster (`linkerd check` passes). See the [Linkerd getting started guide](https://linkerd.io/2/getting-started/) if needed.
+- (Optional) kube-state-metrics running in your cluster, if you want Kubernetes workload entities (deployments, pods) correlated with Linkerd metrics in New Relic. If you already have the [New Relic Kubernetes integration](/docs/kubernetes-pixie/kubernetes-integration/get-started/introduction-kubernetes-integration/) installed, this is already handled — skip the optional scrape job in the collector config. See the [kube-state-metrics Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics) if needed.
+- Kubernetes cluster (EKS, GKE, AKS, self-managed)
+- `kubectl` configured against the target cluster
+- New Relic [ingest license key](/docs/apis/intro-apis/new-relic-api-keys/#ingest-license-key)
+- [Helm](https://helm.sh/docs/intro/install/) installed
+
+## Step 1: Enable Linkerd injection on your namespaces [#inject-linkerd]
+
+If meshing is not already enabled on the namespaces you want to observe, annotate them and restart the workloads:
+
+```bash
+kubectl annotate namespace <YOUR_NAMESPACE> linkerd.io/inject=enabled
+kubectl rollout restart deployment -n <YOUR_NAMESPACE>
+linkerd check --namespace <YOUR_NAMESPACE>
+```
+
+Repeat for every namespace whose services should appear in New Relic. Skip this step if injection is already enabled.
+
+## Step 2: Deploy the OTel Collector [#deploy-collector]
+
+### Create the namespace and license secret
+
+```bash
+kubectl create namespace nr-otel
+
+kubectl -n nr-otel create secret generic nr-license \
+  --from-literal=NEW_RELIC_LICENSE_KEY='<YOUR_NR_INGEST_LICENSE_KEY>' \
+  --from-literal=NEWRELIC_OTLP_ENDPOINT='https://otlp.nr-data.net:443'
+  # EU accounts: https://otlp.eu01.nr-data.net:443
+```
+
+### Apply the collector manifest
+
+Copy the manifest below into a file named `otel-collector.yaml`. Set `<YOUR_CLUSTER_NAME>` in the `OTEL_RESOURCE_ATTRIBUTES` env var, then apply:
+
+**Customise before applying:**
+
+| Field | Location | What to set |
+|---|---|---|
+| `OTEL_RESOURCE_ATTRIBUTES` | Deployment env | `k8s.cluster.name=<your-cluster>` |
+| `resourcedetection.detectors` | ConfigMap | Optionally add `eks`/`gke`/`azure` for cloud attributes |
+| `kube-state-metrics` target | ConfigMap scrape_configs | Update if KSM is not in `kube-system` |
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata: { name: nr-otel-collector, namespace: nr-otel }
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata: { name: nr-otel-collector }
+rules:
+  - apiGroups: [""]
+    resources: [pods, nodes, endpoints, services, namespaces]
+    verbs: [get, list, watch]
+  - apiGroups: ["apps"]
+    resources: [replicasets, deployments, daemonsets]
+    verbs: [get, list, watch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata: { name: nr-otel-collector }
+roleRef: { apiGroup: rbac.authorization.k8s.io, kind: ClusterRole, name: nr-otel-collector }
+subjects:
+  - { kind: ServiceAccount, name: nr-otel-collector, namespace: nr-otel }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata: { name: nr-otel-config, namespace: nr-otel }
+data:
+  config.yaml: |
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: 'linkerd-controller'
+              kubernetes_sd_configs:
+                - role: pod
+                  namespaces: { names: ['linkerd', 'linkerd-viz'] }
+              relabel_configs:
+                - { source_labels: [__meta_kubernetes_pod_container_port_name], action: keep, regex: admin-http }
+                - { source_labels: [__meta_kubernetes_pod_container_name], target_label: component }
+                - { source_labels: [__meta_kubernetes_namespace], target_label: namespace }
+                - { source_labels: [__meta_kubernetes_pod_name], target_label: pod }
+
+            - job_name: 'linkerd-proxy'
+              kubernetes_sd_configs: [{ role: pod }]
+              relabel_configs:
+                - { source_labels: [__meta_kubernetes_pod_container_name, __meta_kubernetes_pod_container_port_name, __meta_kubernetes_pod_label_linkerd_io_control_plane_ns], action: keep, regex: ^linkerd-proxy;linkerd-admin;linkerd$$ }
+                - { source_labels: [__meta_kubernetes_namespace], target_label: namespace }
+                - { source_labels: [__meta_kubernetes_pod_name], target_label: pod }
+                - { source_labels: [__meta_kubernetes_pod_label_linkerd_io_control_plane_ns], target_label: linkerd_control_plane_ns }
+                - { source_labels: [__meta_kubernetes_pod_label_linkerd_io_control_plane_component], target_label: linkerd_control_plane_component }
+
+            # Optional: enable to correlate Linkerd metrics with Kubernetes workload entities.
+            - job_name: 'kube-state-metrics'
+              static_configs:
+                - targets: ['kube-state-metrics.kube-system.svc.cluster.local:8080']
+              metric_relabel_configs:
+                - { source_labels: [deployment], target_label: k8s.deployment.name, regex: (.+) }
+                - { source_labels: [pod], target_label: k8s.pod.name, regex: (.+) }
+                - { source_labels: [node], target_label: k8s.node.name, regex: (.+) }
+
+      otlp:
+        protocols:
+          grpc: { endpoint: "0.0.0.0:4317" }
+          http: { endpoint: "0.0.0.0:4318" }
+
+      filelog:
+        include: [ /var/log/pods/*/*/*.log ]
+        include_file_path: true
+        start_at: end
+        operators:
+          - type: container
+            add_metadata_from_filepath: true
+
+    processors:
+      memory_limiter: { check_interval: <CHECK_INTERVAL>, limit_percentage: <LIMIT_PERCENTAGE>, spike_limit_percentage: <SPIKE_LIMIT_PERCENTAGE> }
+
+      k8sattributes:
+        auth_type: serviceAccount
+        passthrough: false
+        extract:
+          metadata: [ k8s.deployment.name, k8s.node.name ]
+          labels:
+            - { tag_name: linkerd_control_plane_ns, key: linkerd.io/control-plane-ns, from: pod }
+            - { tag_name: linkerd_control_plane_component, key: linkerd.io/control-plane-component, from: pod }
+        pod_association:
+          - sources:
+              - { from: resource_attribute, name: k8s.pod.name }
+              - { from: resource_attribute, name: k8s.namespace.name }
+
+      k8sattributes/traces:
+        auth_type: serviceAccount
+        passthrough: false
+        extract:
+          metadata: [ k8s.deployment.name, k8s.node.name, k8s.namespace.name, k8s.pod.name ]
+          labels:
+            - { tag_name: linkerd_control_plane_ns, key: linkerd.io/control-plane-ns, from: pod }
+            - { tag_name: linkerd_control_plane_component, key: linkerd.io/control-plane-component, from: pod }
+        pod_association:
+          - sources: [{ from: resource_attribute, name: k8s.pod.ip }]
+          - sources: [{ from: connection }]
+
+      filter/onlyproxy:
+        error_mode: ignore
+        logs:
+          log_record:
+            - 'resource.attributes["k8s.container.name"] != "linkerd-proxy" and not IsMatch(resource.attributes["linkerd_control_plane_component"], ".+")'
+
+      resource/strip_service:
+        attributes:
+          - { key: service.name, action: delete }
+          - { key: service.instance.id, action: delete }
+
+      resourcedetection:
+        detectors: [env]
+        override: false
+
+      transform/k8s:
+        metric_statements:
+          - context: datapoint
+            statements:
+              - set(attributes["k8s.namespace.name"], attributes["namespace"]) where attributes["namespace"] != nil
+              - set(attributes["k8s.pod.name"], attributes["pod"]) where attributes["pod"] != nil
+              - delete_key(attributes, "instance")
+
+      transform/deployment:
+        metric_statements:
+          - context: datapoint
+            statements:
+              - set(attributes["k8s.deployment.name"], attributes["k8s.pod.name"]) where attributes["k8s.deployment.name"] == nil and attributes["k8s.pod.name"] != nil
+              - replace_pattern(attributes["k8s.deployment.name"], "-[a-z0-9]+-[a-z0-9]+$", "") where attributes["k8s.deployment.name"] == attributes["k8s.pod.name"]
+
+      transform/metadata_nullify:
+        metric_statements:
+          - context: metric
+            statements:
+              - set(description, "")
+              - set(unit, "")
+
+      metricstransform/apm_compat:
+        transforms:
+          - include: http.server.request.duration
+            action: insert
+            new_name: apm.service.transaction.duration
+
+      transform/linkerd_component_inject:
+        trace_statements:
+          - context: span
+            statements:
+              - set(attributes["linkerd_control_plane_component"], "linkerd-proxy")
+                where resource.attributes["service.name"] == "linkerd-proxy"
+                and resource.attributes["linkerd_control_plane_ns"] != nil
+
+      transform/linkerd_service_name:
+        trace_statements:
+          - context: resource
+            statements:
+              - set(attributes["service.name"], attributes["k8s.deployment.name"])
+                where attributes["service.name"] == "linkerd-proxy"
+                and attributes["k8s.deployment.name"] != nil
+
+      # Filters out low-value and debugging-only metrics to reduce ingest volume.
+      # Remove individual conditions below to re-enable a metric group.
+      filter/drop_unused:
+        error_mode: ignore
+        metrics:
+          metric:
+            - 'name == "rustls_info" or name == "proxy_build_info"'
+            - 'name == "scrape_series_added"'
+            - 'name == "control_identity_balancer_queue_latency_seconds"'
+            - 'IsMatch(name, "stack_(poll|create|drop)_total") or name == "stack_poll_total_ms"'
+            - 'IsMatch(name, "tokio_rt_.*")'
+            - 'IsMatch(name, "(inbound|outbound)_http_.*_frame_size_bytes") or name == "outbound_http_route_request_frame_size_bytes"'
+            - 'IsMatch(name, "(inbound|outbound)_tcp_detect_http_duration_seconds")'
+            - 'IsMatch(name, "outbound_tcp_balancer_queue_.*")'
+            - 'name == "scrape_duration_seconds" or name == "scrape_samples_scraped" or name == "scrape_samples_post_metric_relabeling"'
+
+      batch: {}
+
+    exporters:
+      otlphttp:
+        endpoint: "${env:YOUR_NEWRELIC_OTLP_ENDPOINT}"
+        headers:
+          api-key: "${env:YOUR_NEW_RELIC_LICENSE_KEY}"
+
+    service:
+      pipelines:
+        metrics/prometheus:
+          receivers: [prometheus]
+          processors: [memory_limiter, resource/strip_service, resourcedetection, transform/k8s, transform/deployment, transform/metadata_nullify, filter/drop_unused, batch]
+          exporters: [otlphttp]
+
+        metrics/otlp:
+          receivers: [otlp]
+          processors: [memory_limiter, resourcedetection, transform/metadata_nullify, metricstransform/apm_compat, batch]
+          exporters: [otlphttp]
+
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, k8sattributes/traces, resourcedetection, transform/linkerd_component_inject, transform/linkerd_service_name, batch]
+          exporters: [otlphttp]
+
+        logs:
+          receivers: [filelog]
+          processors: [memory_limiter, k8sattributes, resourcedetection, filter/onlyproxy, batch]
+          exporters: [otlphttp]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: nr-otel-collector, namespace: nr-otel }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: nr-otel-collector } }
+  template:
+    metadata:
+      labels: { app: nr-otel-collector }
+      annotations:
+        linkerd.io/inject: enabled
+    spec:
+      serviceAccountName: nr-otel-collector
+      containers:
+        - name: collector
+          image: otel/opentelemetry-collector-contrib:0.119.0
+          args: ["--config=/etc/otel/config.yaml"]
+          env:
+            - { name: OTEL_RESOURCE_ATTRIBUTES, value: "k8s.cluster.name=<YOUR_CLUSTER_NAME>" }
+            - name: YOUR_NEWRELIC_OTLP_ENDPOINT
+              valueFrom: { secretKeyRef: { name: nr-license, key: NEWRELIC_OTLP_ENDPOINT } }
+            - name: YOUR_NEW_RELIC_LICENSE_KEY
+              valueFrom: { secretKeyRef: { name: nr-license, key: NEW_RELIC_LICENSE_KEY } }
+          ports:
+            - { name: otlp-grpc, containerPort: 4317, protocol: TCP }
+            - { name: otlp-http, containerPort: 4318, protocol: TCP }
+          securityContext: { runAsUser: 0 }
+          resources:
+            requests: { cpu: 200m, memory: 256Mi }
+            limits:   { cpu: 1000m, memory: 1Gi }
+          volumeMounts:
+            - { name: cfg, mountPath: /etc/otel }
+            - { name: varlogpods, mountPath: /var/log/pods, readOnly: true }
+      volumes:
+        - { name: cfg, configMap: { name: nr-otel-config } }
+        - { name: varlogpods, hostPath: { path: /var/log/pods } }
+---
+# appProtocol: grpc is required so Linkerd routes OTLP correctly.
+# Without it, Linkerd treats port 4317 as HTTP/1.1 and gRPC export fails.
+apiVersion: v1
+kind: Service
+metadata: { name: nr-otel-collector, namespace: nr-otel }
+spec:
+  selector: { app: nr-otel-collector }
+  ports:
+    - { name: otlp-grpc, port: 4317, targetPort: 4317, protocol: TCP, appProtocol: grpc }
+    - { name: otlp-http, port: 4318, targetPort: 4318, protocol: TCP }
+```
+
+```bash
+kubectl apply -f otel-collector.yaml
+kubectl rollout status deployment/nr-otel-collector -n nr-otel
+```
+
+The following table describes the key configuration parameters:
+
+<table>
+  <thead>
+    <tr>
+      <th>Parameter</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`k8s.cluster.name`</td>
+      <td>Your Kubernetes cluster name, set via the `OTEL_RESOURCE_ATTRIBUTES` env var. Used to identify the cluster in New Relic.</td>
+    </tr>
+    <tr>
+      <td>`kube-state-metrics` target</td>
+      <td>Scrape target for kube-state-metrics. Default is `kube-state-metrics.kube-system.svc.cluster.local:8080`. Update if KSM is installed in a different namespace.</td>
+    </tr>
+    <tr>
+      <td>`resourcedetection.detectors`</td>
+      <td>Cloud provider detectors to enrich metrics with host metadata. Add `eks`, `gke`, or `azure` to match your environment.</td>
+    </tr>
+    <tr>
+      <td>`check_interval`</td>
+      <td>How often the memory limiter checks memory usage. The default value is `1s`.</td>
+    </tr>
+    <tr>
+      <td>`limit_percentage`</td>
+      <td>Maximum percentage of available memory the collector may use before it starts dropping data. The default value is `80`.</td>
+    </tr>
+    <tr>
+      <td>`spike_limit_percentage`</td>
+      <td>Percentage of memory reserved to absorb sudden spikes before the limit is hit. The default value is `25`.</td>
+    </tr>
+    <tr>
+      <td>`resources.requests` / `resources.limits`</td>
+      <td>CPU and memory requests and limits for the collector pod. Defaults are `200m`/`256Mi` (requests) and `1000m`/`1Gi` (limits). Adjust based on your cluster size and scrape volume.</td>
+    </tr>
+  </tbody>
+</table>
+
+The collector deploys four pipelines:
+
+| Pipeline | Purpose |
+|---|---|
+| `metrics/prometheus` | Scrapes Linkerd proxy + control plane + kube-state-metrics |
+| `metrics/otlp` | Receives OTel SDK metrics from app pods (APM path) |
+| `traces` | Receives app traces + Linkerd proxy traces (2.19+) |
+| `logs` | Tails `linkerd-proxy` container logs |
+
+The `filter/drop_unused` processor reduces ingest by approximately 31% by disabling debugging and low-value metrics. To re-enable a metric group, remove the corresponding condition from that processor. See [Linkerd metrics reference](/docs/opentelemetry/integrations/linkerd/linkerd-otel-metrics-reference/) for details on which metrics are disabled by default.
+
+## Verify basic setup [#verify-basic]
+
+Run these queries in the [New Relic query builder](https://one.newrelic.com/data-exploration) after a few minutes:
+
+```sql
+-- Confirm Linkerd proxy metrics are flowing
+SELECT count(*) FROM Metric
+WHERE k8s.cluster.name = '<YOUR_CLUSTER>'
+  AND linkerd_control_plane_ns IS NOT NULL
+SINCE 5 minutes ago
+```
+
+```sql
+-- Confirm per-service request rates
+SELECT rate(sum(request_total), 1 minute) AS 'Req/min'
+FROM Metric
+WHERE k8s.cluster.name = '<YOUR_CLUSTER>'
+  AND linkerd_control_plane_component IS NULL
+FACET k8s.deployment.name
+SINCE 30 minutes ago
+```
+
+```sql
+-- Confirm Kubernetes workload entities exist
+SELECT uniques(k8s.deployment.name)
+FROM Metric
+WHERE metricName LIKE 'kube_deployment%'
+  AND k8s.cluster.name = '<YOUR_CLUSTER>'
+SINCE 10 minutes ago
+```
+
+Navigate to **Entity Explorer** and search for your cluster name to find the Linkerd entity with the built-in dashboard.
+
+## Optional: Add distributed tracing (APM) [#apm-setup]
+
+Distributed tracing adds application-level observability on top of the mesh layer: trace waterfalls, per-endpoint latency, and error stack traces. Two sub-steps are required: enabling Linkerd proxy trace export (2.19+) and instrumenting your application pods.
+
+### Enable Linkerd proxy trace export (Linkerd 2.19+)
+
+As of Linkerd 2.19, proxy trace export is configured directly in the control plane, with no cert-manager or separate port required.
+
+<Callout variant="important">
+  The `meshIdentity` stanza is **mandatory**. Linkerd can only export traces to a collector that is inside the mesh. The collector pod already has `linkerd.io/inject: enabled` set in the manifest above. Do not remove it.
+</Callout>
+
+<CollapserGroup>
+
+  <Collapser id="traces-helm" title="Via Helm">
+
+```yaml
+# values.yaml
+proxy:
+  tracing:
+    enabled: true
+    collector:
+      endpoint: nr-otel-collector.nr-otel.svc.cluster.local:4317
+      meshIdentity:
+        serviceAccountName: nr-otel-collector
+        namespace: nr-otel
+```
+
+```bash
+helm upgrade linkerd-control-plane linkerd/linkerd-control-plane \
+  --namespace linkerd --reuse-values -f values.yaml
+```
+
+  </Collapser>
+
+  <Collapser id="traces-cli" title="Alternative: Linkerd CLI">
+
+```bash
+linkerd upgrade \
+  --set proxy.tracing.enabled=true \
+  --set proxy.tracing.collector.endpoint=nr-otel-collector.nr-otel.svc.cluster.local:4317 \
+  --set proxy.tracing.collector.meshIdentity.serviceAccountName=nr-otel-collector \
+  --set proxy.tracing.collector.meshIdentity.namespace=nr-otel \
+  | kubectl apply -f -
+```
+
+  </Collapser>
+
+</CollapserGroup>
+
+Restart all meshed pods to apply the new proxy configuration:
+
+```bash
+kubectl rollout restart deployment -n <YOUR_NAMESPACE>
+```
+
+### Instrument your application pods
+
+Add the OTel Java agent (or the agent for your language) to propagate trace context headers. Linkerd supports both W3C Trace Context and B3 formats. The OTel agent handles this automatically.
+
+<CollapserGroup>
+
+  <Collapser id="apm-operator" title="OTel Operator (recommended)">
+
+```bash
+kubectl apply -f https://github.com/open-telemetry/opentelemetry-operator/releases/latest/download/opentelemetry-operator.yaml
+
+kubectl apply -f - <<'EOF'
+apiVersion: opentelemetry.io/v1alpha1
+kind: Instrumentation
+metadata:
+  name: nr-instrumentation
+  namespace: <YOUR_NAMESPACE>
+spec:
+  exporter:
+    endpoint: http://nr-otel-collector.nr-otel.svc.cluster.local:4317
+  propagators: [tracecontext, baggage]
+  java:
+    image: ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:latest
+EOF
+
+kubectl annotate deployment <YOUR_DEPLOYMENT> \
+  instrumentation.opentelemetry.io/inject-java="true" \
+  -n <YOUR_NAMESPACE>
+```
+
+  </Collapser>
+
+</CollapserGroup>
+
+### Verify APM setup
+
+```sql
+SELECT count(*) FROM Span
+WHERE service.name = '<your-service-name>'
+  AND k8s.cluster.name = '<YOUR_CLUSTER>'
+SINCE 5 minutes ago
+```
+
+## Troubleshooting [#troubleshooting]
+
+<CollapserGroup>
+
+  <Collapser id="no-metrics" title="No metrics in New Relic">
+
+```bash
+kubectl get pods -n nr-otel
+kubectl logs -n nr-otel deployment/nr-otel-collector | grep -E "error|warn|Failed" | tail -20
+```
+
+  </Collapser>
+
+  <Collapser id="no-traces" title="No spans / traces (APM)">
+
+```bash
+# Verify Java agent loaded
+kubectl logs -n <YOUR_NAMESPACE> deployment/<YOUR_APP> | grep "javaagent"
+
+# Verify Linkerd proxy routing for OTLP gRPC (must show appProtocol: grpc)
+kubectl get svc -n nr-otel nr-otel-collector -o jsonpath='{.spec.ports}'
+```
+
+The collector Service port 4317 must have `appProtocol: grpc`. Without it, Linkerd routes gRPC as HTTP/1.1. Fix:
+
+```bash
+kubectl patch svc -n nr-otel nr-otel-collector --type='json' \
+  -p='[{"op":"add","path":"/spec/ports/0/appProtocol","value":"grpc"}]'
+```
+
+  </Collapser>
+
+  <Collapser id="no-cp-ns-on-spans" title="linkerd_control_plane_ns missing from spans">
+
+The `k8sattributes/traces` processor uses `k8s.pod.ip` for pod association. Verify the downward API env var is set on your app pods:
+
+```bash
+kubectl exec -n <YOUR_NAMESPACE> deployment/<YOUR_APP> -- env | grep MY_POD_IP
+```
+
+If `MY_POD_IP` is missing, add it to your pod spec as a `fieldRef` env var pointing to `status.podIP`.
+
+  </Collapser>
+
+  <Collapser id="no-logs" title="No logs in New Relic">
+
+The `filelog` receiver requires the collector to run as root (`runAsUser: 0`) to read `/var/log/pods`. Verify:
+
+```bash
+kubectl exec -n nr-otel deployment/nr-otel-collector -- ls /var/log/pods 2>/dev/null | head -5
+```
+
+  </Collapser>
+
+</CollapserGroup>
+
+## Next steps [#next-steps]
+
+- [Find and query your Linkerd data](/docs/opentelemetry/integrations/linkerd/find-and-query-your-data/)
+- [Linkerd metrics reference](/docs/opentelemetry/integrations/linkerd/linkerd-otel-metrics-reference/)

--- a/src/nav/opentelemetry.yml
+++ b/src/nav/opentelemetry.yml
@@ -140,6 +140,16 @@ pages:
             path: /docs/opentelemetry/integrations/kafka/find-and-query-data
           - title: Metrics reference
             path: /docs/opentelemetry/integrations/kafka/metrics-reference
+      - title: Linkerd integration
+        pages:
+          - title: Overview
+            path: /docs/opentelemetry/integrations/linkerd/linkerd-otel-overview
+          - title: Setup
+            path: /docs/opentelemetry/integrations/linkerd/linkerd-otel-setup
+          - title: Find and query your data
+            path: /docs/opentelemetry/integrations/linkerd/find-and-query-your-data
+          - title: Metrics reference
+            path: /docs/opentelemetry/integrations/linkerd/linkerd-otel-metrics-reference
       - title: NGINX integration
         pages:
           - title: Overview


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

- Adds OpenTelemetry monitoring documentation for Linkerd service mesh — overview, Kubernetes setup guide, find-and-query-your-data, and metrics reference.

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context

* What problems does this PR solve?
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
* If your issue relates to an existing GitHub issue, please link to it.