### PR TITLE
Fix api-Key casing to api-key in Claude Code MCP setup config

### DIFF
--- a/src/content/docs/agentic-ai/mcp/setup.mdx
+++ b/src/content/docs/agentic-ai/mcp/setup.mdx
@@ -93,7 +93,7 @@ Claude Code supports both OAuth (recommended) and API key authentication methods
             "type": "http",
             "url": "https://mcp.newrelic.com/mcp/",
             "headers": {
-              "api-Key": "NRAK-YOUR-KEY-HERE"
+              "api-key": "NRAK-YOUR-KEY-HERE"
             }
           }
         }


### PR DESCRIPTION
Fixes incorrect header casing in the Claude Code API key JSON config example. `api-Key` should be `api-key` (all lowercase).