### PR TITLE
chore(deps): bump uuid 9→11.1.1 and gatsby-transformer-remark 5.24→5.25.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "unist-util-filter": "^2.0.3",
     "unist-util-remove": "^2.0.1",
     "use-boop": "^1.1.1",
-    "uuid": "^14.0.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "gatsby-source-filesystem": "4.25.0",
     "gatsby-transformer-json": "4.25.0",
     "gatsby-transformer-plaintext": "^2.0.0",
-    "gatsby-transformer-remark": "5.24.0",
+    "gatsby-transformer-remark": "5.25.1",
     "gatsby-transformer-sharp": "4.25.0",
     "gatsby-transformer-xml": "^4.24.0",
     "gatsby-transformer-yaml": "4.25.0",
@@ -72,7 +72,7 @@
     "unist-util-filter": "^2.0.3",
     "unist-util-remove": "^2.0.1",
     "use-boop": "^1.1.1",
-    "uuid": "^9.0.1"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "@actions/core": "^1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21665,10 +21665,10 @@ uuid@8.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
   integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
 
-uuid@^14.0.0:
-  version "14.0.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.2.tgz#d5ae03e4db0881c87271f8b0b9bd7312d02c799a"
-  integrity sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==
+uuid@^11.1.1:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
 
 uuid@^3.3.2:
   version "3.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9862,7 +9862,7 @@ gatsby-core-utils@^2.14.0:
     tmp "^0.2.1"
     xdg-basedir "^4.0.0"
 
-gatsby-core-utils@^3.15.0, gatsby-core-utils@^3.24.0, gatsby-core-utils@^3.25.0:
+gatsby-core-utils@^3.15.0, gatsby-core-utils@^3.25.0:
   version "3.25.0"
   resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-3.25.0.tgz#6ebfd2b8c95f3bbc3b52a9619a1ff26c68109c25"
   integrity sha512-lmMDwbnKpqAi+8WWd7MvCTCx3E0u7j8sbVgydERNCYVxKVpzD/aLCH4WPb4EE9m1H1rSm76w0Z+MaentyB/c/Q==
@@ -10292,13 +10292,13 @@ gatsby-transformer-plaintext@^2.0.0:
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-gatsby-transformer-remark@5.24.0:
-  version "5.24.0"
-  resolved "https://registry.yarnpkg.com/gatsby-transformer-remark/-/gatsby-transformer-remark-5.24.0.tgz#1736c83291c8be402dced2b823322acef8f7b896"
-  integrity sha512-xI24Cx1M8yD7zGeBXtmgX8rtm8t3t4RTKkgJAmuAjj6vf/Mi0SIRZUcr27Cqx0ctHUwZQZV5uIbIWfCDml1Y7w==
+gatsby-transformer-remark@5.25.1:
+  version "5.25.1"
+  resolved "https://registry.yarnpkg.com/gatsby-transformer-remark/-/gatsby-transformer-remark-5.25.1.tgz#6df0117dbe3bb39c06e05c85db494948a565b7c8"
+  integrity sha512-6k3uOnZYsJSgmZIWq9Y+Cqb6pysusCUBYpQY1+V9ofpSRbrZGGfuoCeFKd27x/c0jI5jneuL3NXnxwn/JJK1Ig==
   dependencies:
     "@babel/runtime" "^7.15.4"
-    gatsby-core-utils "^3.24.0"
+    gatsby-core-utils "^3.25.0"
     gray-matter "^4.0.3"
     hast-util-raw "^6.0.2"
     hast-util-to-html "^7.1.3"
@@ -21665,6 +21665,11 @@ uuid@8.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.0.0.tgz#bc6ccf91b5ff0ac07bbcdbf1c7c4e150db4dbb6c"
   integrity sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==
 
+uuid@^14.0.0:
+  version "14.0.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-14.0.2.tgz#d5ae03e4db0881c87271f8b0b9bd7312d02c799a"
+  integrity sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==
+
 uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
@@ -21674,11 +21679,6 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-
-uuid@^9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 uvu@^0.5.0, uvu@^0.5.6:
   version "0.5.6"


### PR DESCRIPTION
## Summary

Closes two Dependabot security alerts with direct dependency upgrades.

## Changes

| Package | Before | After | Alert |
|---|---|---|---|
| `uuid` | `^9.0.1` | `^11.1.1` | [#335](https://github.com/newrelic/docs-website/security/dependabot/335) ✅ |
| `gatsby-transformer-remark` | `5.24.0` | `5.25.1` | [#100](https://github.com/newrelic/docs-website/security/dependabot/100) ✅ |

## Why uuid@11.1.1 not uuid@14

uuid@14 has `"type": "module"` with no `"require"` export condition, making it ESM-only. `@netlify/plugin-gatsby`'s post-build processing calls `require('uuid')` in a CJS context — uuid@14 fails here with exit code 2 (confirmed across 3 consecutive Netlify build failures).

uuid@11.1.1 exports both `"require": "./dist/cjs/index.js"` and `"import": "./dist/esm/index.js"` under the node condition, satisfying both CJS and ESM consumers. 11.1.1 is the minimum patched version for alert #335.

## Why gatsby-transformer-remark@5.25.1 is safe

Same `gatsby: "^4.0.0-next"` peer dep as 5.24.0. Only dep change: `gatsby-core-utils: "^3.24.0"` → `"^3.25.0"`. No Gatsby version change required.

## Only v4 of uuid is used in this repo

`FeedbackModal.js`: `import { v4 as uuidv4 } from 'uuid'`. The alert covers the `v3/v5/v6` path with a `buf` argument — that path is never called here.

## Validation

- `yarn install --frozen-lockfile` passes
- `require('uuid')` confirmed working with 11.1.1 (`require` export path exists)