### PR TITLE
Update filter-new-relic-one-dashboards-facets.mdx to document the use of a new {{selfEntity}} variable in facet linking

### DIFF
--- a/src/content/docs/query-your-data/explore-query-data/dashboards/filter-new-relic-one-dashboards-facets.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/filter-new-relic-one-dashboards-facets.mdx
@@ -31,12 +31,12 @@ Requirements to use this feature:
 * Must use a [New Relic dashboard](/docs/dashboards/new-relic-one-dashboards/get-started/introduction-new-relic-one-dashboards). Will not work on a standalone chart in the [query builder](/docs/chart-builder/use-chart-builder/get-started/introduction-chart-builder).
 * NRQL query must contain a [`FACET` clause](/docs/query-data/nrql-new-relic-query-language/getting-started/nrql-syntax-components-functions#sel-facet).
 * Available only for [bar charts](/docs/insights/use-insights-ui/manage-dashboards/chart-types#widget-barchart), [heat maps](/docs/insights/use-insights-ui/manage-dashboards/chart-types#widget-heatmap), [pie charts](/docs/insights/use-insights-ui/manage-dashboards/chart-types#widget-piechart), and [tables](/docs/insights/use-insights-ui/manage-dashboards/chart-types#widget-table).
-* New! - You can now use a variable {{selfEntity}} to ensure facet linking so facet linking is always linked to the current dashboard even when you duplicate a dashboard. To enable this functionality in the UI:
+* New: You can now use a variable {{selfEntity}} to keep facet linking tied to the current dashboard, even when you duplicate it. To enable this functionality in the UI:
     * For existing dashboards: Disable facet linking in the widget used for filtering and apply the changes. Enable facet linking again in the same widget and apply the changes. This will replace the dashboard GUID with the {{selfEntity}} variables.
-    * For new dashboards: It will use {{selfEntity}} variable automatically when you enable facet linking.
-    * For terraform/json dashboards:  
-        * In existing dashboards - Remove the hardcoded linkedEntityGuids at widget level and replace it with "{{selfEntity}}" in the raw configuration. 
-        * In new dashboards: Simply add this line in the raw configuration of the widget you want to facet by: 
+    * For new dashboards: It will use the {{selfEntity}} variable automatically when you enable facet linking.
+    * For terraform/json dashboards:
+        * For existing dashboards: Remove the hardcoded linkedEntityGuids at widget level and replace it with "{{selfEntity}}" in the raw configuration.
+        * For new dashboards: Add this line in the raw configuration of the widget you want to facet by:
 
     ```json
                         "linkedEntityGuids": [

--- a/src/content/docs/query-your-data/explore-query-data/dashboards/filter-new-relic-one-dashboards-facets.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/filter-new-relic-one-dashboards-facets.mdx
@@ -31,6 +31,18 @@ Requirements to use this feature:
 * Must use a [New Relic dashboard](/docs/dashboards/new-relic-one-dashboards/get-started/introduction-new-relic-one-dashboards). Will not work on a standalone chart in the [query builder](/docs/chart-builder/use-chart-builder/get-started/introduction-chart-builder).
 * NRQL query must contain a [`FACET` clause](/docs/query-data/nrql-new-relic-query-language/getting-started/nrql-syntax-components-functions#sel-facet).
 * Available only for [bar charts](/docs/insights/use-insights-ui/manage-dashboards/chart-types#widget-barchart), [heat maps](/docs/insights/use-insights-ui/manage-dashboards/chart-types#widget-heatmap), [pie charts](/docs/insights/use-insights-ui/manage-dashboards/chart-types#widget-piechart), and [tables](/docs/insights/use-insights-ui/manage-dashboards/chart-types#widget-table).
+* New! - You can now use a variable {{selfEntity}} to ensure facet linking so facet linking is always linked to the current dashboard even when you duplicate a dashboard. To enable this functionality in the UI:
+    * For existing dashboards: Disable facet linking in the widget used for filtering and apply the changes. Enable facet linking again in the same widget and apply the changes. This will replace the dashboard GUID with the {{selfEntity}} variables.
+    * For new dashboards: It will use {{selfEntity}} variable automatically when you enable facet linking.
+    * For terraform/json dashboards:  
+        * In existing dashboards - Remove the hardcoded linkedEntityGuids at widget level and replace it with "{{selfEntity}}" in the raw configuration. 
+        * In new dashboards: Simply add this line in the raw configuration of the widget you want to facet by: 
+
+    ```json
+                        "linkedEntityGuids": [
+                            "{{selfEntity}}"
+                        ],
+    ```
 
 ## Example use of facet filtering [#example-use]
 

--- a/src/content/docs/query-your-data/explore-query-data/dashboards/filter-new-relic-one-dashboards-facets.mdx
+++ b/src/content/docs/query-your-data/explore-query-data/dashboards/filter-new-relic-one-dashboards-facets.mdx
@@ -31,7 +31,7 @@ Requirements to use this feature:
 * Must use a [New Relic dashboard](/docs/dashboards/new-relic-one-dashboards/get-started/introduction-new-relic-one-dashboards). Will not work on a standalone chart in the [query builder](/docs/chart-builder/use-chart-builder/get-started/introduction-chart-builder).
 * NRQL query must contain a [`FACET` clause](/docs/query-data/nrql-new-relic-query-language/getting-started/nrql-syntax-components-functions#sel-facet).
 * Available only for [bar charts](/docs/insights/use-insights-ui/manage-dashboards/chart-types#widget-barchart), [heat maps](/docs/insights/use-insights-ui/manage-dashboards/chart-types#widget-heatmap), [pie charts](/docs/insights/use-insights-ui/manage-dashboards/chart-types#widget-piechart), and [tables](/docs/insights/use-insights-ui/manage-dashboards/chart-types#widget-table).
-* New: You can now use a variable {{selfEntity}} to keep facet linking tied to the current dashboard, even when you duplicate it. To enable this functionality in the UI:
+* You can use a variable {{selfEntity}} to keep facet linking tied to the current dashboard, even when you duplicate it. To enable this functionality in the UI:
     * For existing dashboards: Disable facet linking in the widget used for filtering and apply the changes. Enable facet linking again in the same widget and apply the changes. This will replace the dashboard GUID with the {{selfEntity}} variables.
     * For new dashboards: It will use the {{selfEntity}} variable automatically when you enable facet linking.
     * For terraform/json dashboards:


### PR DESCRIPTION
This feature will be available to customers from the 16th of September - do not publish until then. Thanks Related NR feature: https://new-relic.atlassian.net/browse/NR-432983


## Give us some context

* What problems does this PR solve?
Allows the use of {{selfEntity}} variable in facet linking (currently uses hardcoded dashboard GUID)
* Add any context that will help us review your changes such as testing notes,
  links to related docs, screenshots, etc.
  N/A
* If your issue relates to an existing GitHub issue, please link to it.