### PR TITLE
docs: clarify GCP WIF pool/provider name flexibility

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/install-and-configure/connect-gcp-workload-identity-federation.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/install-and-configure/connect-gcp-workload-identity-federation.mdx
@@ -159,7 +159,7 @@ These are the requirements for the integration:
     5. Select <DNT>**Continue**</DNT>.
 
     <Callout variant="tip">
-      The pool and provider names shown in the New Relic UI are only suggestions. You can name them to match your own naming convention (for example, `prod`, `qa`, or `staging`) instead of using the New Relic default. If you rename the pool or provider in GCP after finishing the New Relic integration, you must redo the integration in New Relic so it points to the new names.
+      The pool and provider names shown in the New Relic UI are only suggestions. You can name them to match your own naming convention (for example, `prod`, `qa`, or `staging`) instead of using the New Relic default. If you rename the pool or provider in GCP after finishing the New Relic integration, you must redo the integration so it points to the new names.
     </Callout>
 
     {/* Image needed: create an identity pool screen showing provider name, issuer URL, and audience fields pre-filled from New Relic */}

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/install-and-configure/connect-gcp-workload-identity-federation.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/install-and-configure/connect-gcp-workload-identity-federation.mdx
@@ -158,6 +158,10 @@ These are the requirements for the integration:
     4. Copy the <DNT>**Audience URL**</DNT> from the New Relic UI.
     5. Select <DNT>**Continue**</DNT>.
 
+    <Callout variant="tip">
+      The pool and provider names shown in the New Relic UI are only suggestions. You can name them to match your own naming convention (for example, `prod`, `qa`, or `staging`) instead of using the New Relic default. If you rename the pool or provider in GCP after finishing the New Relic integration, you must redo the integration in New Relic so it points to the new names.
+    </Callout>
+
     {/* Image needed: create an identity pool screen showing provider name, issuer URL, and audience fields pre-filled from New Relic */}
   </Step>
 


### PR DESCRIPTION
## Give us some context

* Customers setting up GCP Workload Identity Federation assumed the workload identity pool and OIDC provider names shown in the New Relic setup screen were required values. This PR clarifies they're only suggestions — customers can name them per their own conventions (e.g. `prod`, `qa`, `staging`), with a note that renaming after integration requires redoing the New Relic integration.
* Context / source of truth for this clarification: https://newrelic.slack.com/archives/C0RF9MFSQ/p1788854143561669?thread_ts=1788509779.379059&cid=C0RF9MFSQ