### PR TITLE
Update VS Code MCP API key config: remove inputs block

### DIFF
--- a/src/content/docs/agentic-ai/mcp/overview.mdx
+++ b/src/content/docs/agentic-ai/mcp/overview.mdx
@@ -75,7 +75,7 @@ Accessing the MCP server requires you to be a member of a group that has been as
     - US (default): `https://mcp.newrelic.com/oauth2/token`
     - EU: `https://mcp.eu.newrelic.com/oauth2/token`
     - JP: `https://mcp.jp.newrelic.com/oauth2/token`
-  - Scopes: `["openid"]`
+  - Scopes: `["observability:read", "offline", "offline_access"]`
 
 ## Public preview access
 Navigate to the Previews & Trials page in the New Relic UI and enable the New Relic AI MCP Server preview:

--- a/src/content/docs/agentic-ai/mcp/setup.mdx
+++ b/src/content/docs/agentic-ai/mcp/setup.mdx
@@ -339,20 +339,12 @@ Add the MCP server by editing `.vscode/mcp.json` as shown here:
 
 ```json
 {
-  "inputs": [
-    {
-      "type": "promptString",
-      "id": "nr-api-key",
-      "description": "New Relic User API Key",
-      "password": true
-    }
-  ],
   "servers": {
     "new-relic-mcp": {
       "type": "http",
       "url": "https://mcp.newrelic.com/mcp/",
       "headers": {
-        "api-key": "${input:nr-api-key}"
+        "api-key": "NRAK-YOUR-KEY-HERE"
       }
     }
   }


### PR DESCRIPTION
Simplifies the VS Code API key config by removing the promptString inputs block and using a plain API key placeholder, per updated guidance from engineering.