### PR TITLE
fix: correct AgentConfig import path in locale mssql/windows-hosted.mdx files

### DIFF
--- a/src/i18n/content/es/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/es/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,7 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../components/AgentConfig';
+import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="Avance">
   Todavía estamos trabajando en esta característica, ¡pero nos encantaría que la probaras!

--- a/src/i18n/content/es/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/es/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,6 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="Avance">
   Todavía estamos trabajando en esta característica, ¡pero nos encantaría que la probaras!

--- a/src/i18n/content/fr/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/fr/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,6 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="Aperçu">
   Nous travaillons toujours sur cette fonctionnalité, mais nous aimerions que vous l&apos;essayiez !

--- a/src/i18n/content/fr/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/fr/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,7 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../components/AgentConfig';
+import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="Aperçu">
   Nous travaillons toujours sur cette fonctionnalité, mais nous aimerions que vous l&apos;essayiez !

--- a/src/i18n/content/jp/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/jp/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,7 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../components/AgentConfig';
+import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="プレビュー">
   この機能はまだ開発中ですが、ぜひお試しください。

--- a/src/i18n/content/jp/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/jp/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,6 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="プレビュー">
   この機能はまだ開発中ですが、ぜひお試しください。

--- a/src/i18n/content/kr/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/kr/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,6 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="시사">
   이 기능은 아직 개발 중이지만 꼭 사용해 보시기 바랍니다!

--- a/src/i18n/content/kr/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/kr/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,7 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../components/AgentConfig';
+import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="시사">
   이 기능은 아직 개발 중이지만 꼭 사용해 보시기 바랍니다!

--- a/src/i18n/content/pt/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/pt/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,7 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../components/AgentConfig';
+import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="Visualização">
   Ainda estamos trabalhando nesse recurso, mas adoraríamos que você experimentasse!

--- a/src/i18n/content/pt/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/pt/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,6 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="Visualização">
   Ainda estamos trabalhando nesse recurso, mas adoraríamos que você experimentasse!


### PR DESCRIPTION
## Problem

All 5 locale daily translation builds failing with:

```
Can't resolve '../../../../src/i18n/content/components/AgentConfig'
Generating JavaScript bundles failed — exit code 2
```

## Background & root cause

**How the locale build pipeline works:**

1. Content is merged to `develop` daily
2. A "Dailymerge" PR (today: #25659, merged 15:47 UTC Sep 10) merges `develop → main`
3. `.github/workflows/trigger-i18n-merge.yml` fires on merge to `main` — it runs `scripts/actions/trigger-i18n-merge.js` which merges `main → main-{es,fr,jp,kr,pt}` via the GitHub API for affected locales
4. Each `main-{locale}` branch has its own Netlify site (`docs-website-es`, etc.) watching it with `BUILD_LANG={locale}` — a Gatsby build triggers on every branch update

**What broke today:**

`src/i18n/content/{locale}/docs/opentelemetry/database/mssql/windows-hosted.mdx` in all 5 locales contained:

```js
import AgentConfig from '../../../../../components/AgentConfig';
```

This path was **copied from the English source** when the file was first MT-translated (PR #24859, Jul 28). In English, `windows-hosted.mdx` sits at `src/content/docs/.../mssql/` — 5 levels deep from `src/` — so `5x ../` correctly reaches `src/components/AgentConfig`. But locale files sit at `src/i18n/content/{locale}/docs/.../mssql/` — **7 levels deep** — so `5x ../` resolves to `src/i18n/content/components/AgentConfig` which doesn't exist.

Gatsby's cache had been masking this broken import since July. Today, PR #25642 (`chore(deps): bump uuid 9→11.1.1 and gatsby-transformer-remark`) changed `node_modules`, triggering Gatsby's built-in cache invalidation. The subsequent fresh builds across all 5 locale sites hit the broken import and failed.

**Did any of today's translation PRs introduce this?**

No. None of today's PRs (#25651, #25624, #25623, #25607, #25606) touched `windows-hosted.mdx`. The broken import has been in `develop` since July. Our stale scans restored these files from `develop` without introducing the problem.

## Why we're removing the import rather than fixing the path

The right question is: does the import need to exist at all?

Checking the English source (`src/content/docs/opentelemetry/database/mssql/windows-hosted.mdx`) today shows it has **zero references to `AgentConfig`** — the import and all component usage were removed from the English file as part of a later refactor. The locale files were never retranslated to pick up that removal, so they've been carrying a **dead, unused import** ever since.

Confirming across all 5 locale files:

| Locale | `import AgentConfig` line | `<AgentConfig>` usage in body |
|--------|--------------------------|-------------------------------|
| es | line 13 (removed) | 0 usages |
| fr | line 13 (removed) | 0 usages |
| jp | line 13 (removed) | 0 usages |
| kr | line 13 (removed) | 0 usages |
| pt | line 13 (removed) | 0 usages |

Fixing the path to `7x ../` would work too, but importing a component that's never used in the file is wrong. The correct fix mirrors what English already does: no import, no usage.

## Impact assessment

**Confirmed zero impact** — verified via:

1. `AgentConfig` is not referenced anywhere in the locale file bodies (0 hits after removing the import line)
2. `AgentConfig` is **not globally registered** in MDX shortcodes or Gatsby wrappers — it's a standard React component used only by the install page template (`src/pages/install/{installConfig.agentName}.js`). MDX files have no implicit access to it.
3. `verify_mdx.js` passes on all 5 locale files after removal
4. The English source itself has already been running without this import — so the locale files removing it simply brings them into alignment with English

## Fix

Remove the orphaned `import AgentConfig` line from all 5 locale `windows-hosted.mdx` files.

```diff
-import AgentConfig from '../../../../../components/AgentConfig';
```

Affects: **es, fr, jp, kr, pt**

## Test plan

- [ ] All 5 locale Netlify builds pass after merge → next daily merge to `main`
