### PR TITLE
fix: remove dead AgentConfig import breaking all locale Netlify builds (Sep 10 Hotfix)

### DIFF
--- a/src/i18n/content/es/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/es/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,7 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../components/AgentConfig';
+import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="Avance">
   Todavía estamos trabajando en esta característica, ¡pero nos encantaría que la probaras!

--- a/src/i18n/content/es/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/es/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,6 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="Avance">
   Todavía estamos trabajando en esta característica, ¡pero nos encantaría que la probaras!

--- a/src/i18n/content/fr/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/fr/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,6 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="Aperçu">
   Nous travaillons toujours sur cette fonctionnalité, mais nous aimerions que vous l&apos;essayiez !

--- a/src/i18n/content/fr/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/fr/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,7 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../components/AgentConfig';
+import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="Aperçu">
   Nous travaillons toujours sur cette fonctionnalité, mais nous aimerions que vous l&apos;essayiez !

--- a/src/i18n/content/jp/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/jp/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,7 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../components/AgentConfig';
+import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="プレビュー">
   この機能はまだ開発中ですが、ぜひお試しください。

--- a/src/i18n/content/jp/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/jp/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,6 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="プレビュー">
   この機能はまだ開発中ですが、ぜひお試しください。

--- a/src/i18n/content/kr/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/kr/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,6 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="시사">
   이 기능은 아직 개발 중이지만 꼭 사용해 보시기 바랍니다!

--- a/src/i18n/content/kr/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/kr/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,7 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../components/AgentConfig';
+import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="시사">
   이 기능은 아직 개발 중이지만 꼭 사용해 보시기 바랍니다!

--- a/src/i18n/content/pt/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/pt/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,7 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../components/AgentConfig';
+import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="Visualização">
   Ainda estamos trabalhando nesse recurso, mas adoraríamos que você experimentasse!

--- a/src/i18n/content/pt/docs/opentelemetry/database/mssql/windows-hosted.mdx
+++ b/src/i18n/content/pt/docs/opentelemetry/database/mssql/windows-hosted.mdx
@@ -10,7 +10,6 @@ freshnessValidatedDate: never
 translationType: machine
 ---
 
-import AgentConfig from '../../../../../../../components/AgentConfig';
 
 <Callout title="Visualização">
   Ainda estamos trabalhando nesse recurso, mas adoraríamos que você experimentasse!


### PR DESCRIPTION
## Hotfix — unblocks all 5 locale translation builds

All locale Netlify builds (`docs-website-es/fr/jp/kr/pt`) have been failing since today's daily merge triggered fresh Gatsby builds that exposed a broken import dormant since July.

**See PR #25661 for the full investigation.** Short version:

- `src/i18n/content/{locale}/docs/opentelemetry/database/mssql/windows-hosted.mdx` in all 5 locales had an orphaned `import AgentConfig` line left over from a translation batch in July (MT PR #24859)
- The English source removed that import and all `AgentConfig` usage in a later refactor — but locale files were never retranslated to match
- The import referenced a non-existent path (`src/i18n/content/components/AgentConfig`) — wrong relative depth for locale files
- Gatsby's cache masked it until today's package bump (PR #25642) forced a cache-clear and fresh build

**Fix:** Remove the dead import from all 5 locale files. The component is not used anywhere in the file bodies (confirmed: 0 references across all locales). English runs fine without it.

```diff
-import AgentConfig from '../../../../../components/AgentConfig';
```

**What happens when this merges:**
`trigger-i18n-merge.yml` fires automatically on merge to `main`, detects the 5 locale files in the diff, and merges `main → main-{es,fr,jp,kr,pt}`. All 5 Netlify locale builds trigger and should pass.

No manual intervention needed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)