### PR TITLE
endpoint fix

### DIFF
--- a/src/content/docs/infrastructure/prometheus-integrations/view-query-data/grafana.mdx
+++ b/src/content/docs/infrastructure/prometheus-integrations/view-query-data/grafana.mdx
@@ -23,9 +23,9 @@ Before using this API, you'll need:
 
 To translate a Grafana dashboard to a New Relic dashboard, send a `POST` request to the appropriate endpoint for your region with the dashboard you want to translate in the body of the request.
 
-* US: `https://prometheus-api.newrelic.com/api/v1/translate/dashboard/grafana`
-* EU: `https://prometheus-api.eu.newrelic.com/api/v1/translate/dashboard/grafana`
-* JP: `https://prometheus-api.jp.newrelic.com/api/v1/translate/dashboard/grafana`
+* US: `https://promql-gateway.service.newrelic.com/api/v1/translate/dashboard/grafana`
+* EU: `https://promql-gateway.service.eu.newrelic.com/api/v1/translate/dashboard/grafana`
+* JP: `https://promql-gateway.service.jp.newrelic.com/api/v1/translate/dashboard/grafana`
 
 ## API reference [#api-reference]
 


### PR DESCRIPTION
<!-- Thanks for contributing to our docs! -->

<!-- For Japanese readers: 
もしドキュメントの日本語訳で問題を見つけた場合はPRではなくissueを提出してください。
日本語訳へのPRについてはまだ取り込む準備ができていません。-->

Please follow [conventional commit standards](https://www.conventionalcommits.org/en/v1.0.0/)
in your commit messages and pull request title.

## Give us some context
Fixes the domain on for the translation endpoints. 

https://prometheus-api.newrelic.com is for querying NRDB using PromQL syntax. 
https://promql-gateway.service.newrelic.com is for translating Grafana Dashboards into NR dashboards. 

The page being updated is for translating Grafana dashboards, so should use https://promql-gateway.service.newrelic.com instead of https://prometheus-api.newrelic.com