### PR TITLE
feat(.net agent): Document kafka metrics configuration settings

### DIFF
--- a/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
+++ b/src/content/docs/apm/agents/net-agent/configuration/net-agent-configuration.mdx
@@ -2053,6 +2053,7 @@ Use these options to enable, disable, and configure New Relic features. New Reli
 * [Code level metrics](#code_level_metrics)
 * [Cloud provider metadata](#cloud)
 * [AI monitoring](#ai_monitoring)
+* [Kafka metrics](#kafka_metrics)
 
 ### App pools [#include_exclude_apps]
 
@@ -4004,6 +4005,135 @@ The `aiMonitoring` element supports the following sub-elements:
     ```ini
     NEW_RELIC_AI_MONITORING_RECORD_CONTENT_ENABLED=false
     ```
+  </Collapser>
+</CollapserGroup>
+
+### Kafka metrics [#kafka_metrics]
+
+The `kafka` element is a child of the `configuration` element. Use `kafka` to configure the Kafka metrics that the agent collects from your application's Kafka producers and consumers.
+
+The `kafka` element supports the `metrics` sub-element. All attributes of `metrics` are optional.
+
+```xml
+<kafka>
+  <metrics debugEnabled="true" interval="30" clusterMetricsEnabled="true" />
+</kafka>
+```
+
+You can also configure these attributes with environment variables:
+
+```ini
+NEW_RELIC_KAFKA_METRICS_DEBUG_ENABLED=true
+NEW_RELIC_KAFKA_METRICS_INTERVAL=30
+NEW_RELIC_KAFKA_METRICS_CLUSTER_METRICS_ENABLED=true
+```
+
+The `metrics` sub-element supports the following attributes:
+
+<CollapserGroup>
+  <Collapser
+    id="kafka-metrics-debug-enabled"
+    title="debugEnabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `true`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable collection of the internal Kafka metrics that the agent builds from the statistics Kafka reports to it.
+
+    This attribute takes precedence over the `NewRelic.KafkaInternalMetricsEnabled` app setting. If you do not set `debugEnabled`, the agent still honors that app setting.
+
+    Or use the `NEW_RELIC_KAFKA_METRICS_DEBUG_ENABLED` environment variable.
+  </Collapser>
+
+  <Collapser
+    id="kafka-metrics-interval"
+    title="interval"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Integer
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            (none)
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    This attribute sets the interval, in seconds, at which Kafka reports statistics to the agent.
+
+    The minimum value is 5 seconds. The agent raises a smaller value to 5.
+
+    If you do not set this attribute, the agent derives the interval from the metrics harvest cycle. If you configure a statistics interval on the Kafka client itself, that value takes precedence over this attribute.
+
+    Or use the `NEW_RELIC_KAFKA_METRICS_INTERVAL` environment variable.
+  </Collapser>
+
+  <Collapser
+    id="kafka-metrics-cluster-metrics-enabled"
+    title="clusterMetricsEnabled"
+  >
+    <table>
+      <tbody>
+        <tr>
+          <th>
+            Type
+          </th>
+
+          <td>
+            Boolean
+          </td>
+        </tr>
+
+        <tr>
+          <th>
+            Default
+          </th>
+
+          <td>
+            `false`
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    Enable or disable per-cluster Kafka produce and consume metrics. Set this attribute to `true` to make the agent record cluster metrics.
+
+    Or use the `NEW_RELIC_KAFKA_METRICS_CLUSTER_METRICS_ENABLED` environment variable.
   </Collapser>
 </CollapserGroup>
 


### PR DESCRIPTION
## Give us some context

The .NET agent v10.55.0 gains a new `<kafka><metrics>` configuration element, and no public documentation covered it. This PR adds one subsection to the .NET agent configuration document. It is the only change.

The new `### Kafka metrics [#kafka_metrics]` subsection sits at the end of `## Feature options`, beside Code level metrics, Cloud provider metadata, and AI monitoring. It also joins the bulleted index at the top of that section. It documents the three optional attributes of the `metrics` sub-element:

| Attribute | Type | Default | Environment variable |
|---|---|---|---|
| `debugEnabled` | Boolean | `true` | `NEW_RELIC_KAFKA_METRICS_DEBUG_ENABLED` |
| `interval` | Integer, seconds | (none) | `NEW_RELIC_KAFKA_METRICS_INTERVAL` |
| `clusterMetricsEnabled` | Boolean | `false` | `NEW_RELIC_KAFKA_METRICS_CLUSTER_METRICS_ENABLED` |

### Structure

The subsection follows the `applicationLogging` pattern already in this document: prose, one XML example, one block of environment variables, then a `CollapserGroup` with one `Collapser` per attribute carrying a Type/Default table. Each attribute needs its own explanation, such as the 5-second floor on `interval` and the precedence of `debugEnabled` over the `NewRelic.KafkaInternalMetricsEnabled` app setting.