### PR TITLE
docs(change-tracking): clarify REST deployment API EOL and migration path

### DIFF
--- a/src/content/docs/apis/rest-api-v2/migrate-to-nerdgraph.mdx
+++ b/src/content/docs/apis/rest-api-v2/migrate-to-nerdgraph.mdx
@@ -450,6 +450,21 @@ For more information, see [Introduction to the Metric API](/docs/data-apis/inges
 
 ## Deployments
 
+This section covers migrating deployment recording from both REST APIs reaching end of life on July 31, 2027:
+
+* The REST API v2 deployment endpoints (`https://api.newrelic.com/v2/applications/{app_id}/deployments.json`), shown below.
+* The legacy Deployments v0 API (`deployments.xml`), served on both the `rpm` and `api` hosts in each region — `https://rpm.newrelic.com/deployments.xml` and `https://api.newrelic.com/deployments.xml` (US), plus their `.eu.` equivalents.
+
+Both migrate to NerdGraph change tracking. Record deployments with the `changeTrackingCreateEvent` mutation, and query them with NRQL.
+
+<Callout variant="tip">
+  Not sure where you still record deployments through these REST APIs? Change tracking adds a `newrelic.source` attribute to each event, so you can find your existing REST usage across your whole estate from the New Relic UI or with NRQL. See [how your changes are recorded across your estate](/docs/change-tracking/view-analyze-data/#recording-source) in the change tracking docs.
+</Callout>
+
+<Callout variant="tip">
+  The older `changeTrackingCreateDeployment` NerdGraph mutation is a separate, non-REST mutation that is **not** part of this end of life and continues to work. New Relic recommends `changeTrackingCreateEvent` for new work because it accepts `entitySearch` and supports custom attributes, categories, and types. See [Track changes using NerdGraph](/docs/change-tracking/config/nerdgraph/) for both mutations.
+</Callout>
+
 ### List deployments
 
 **REST API v2:** `GET /v2/applications/{app_id}/deployments.json`
@@ -517,7 +532,7 @@ mutation {
 ```
 
 <Callout variant="tip">
-  Like some other NerdGraph operations, `changeTrackingCreateEvent` accepts an `entitySearch` making it the easiest migration path from the REST API. You can search by `name` as well as by `entityGuid` if you have it. See [Track changes using NerdGraph](/docs/change-tracking/change-tracking-graphql/) for all available fields.
+  Like some other NerdGraph operations, `changeTrackingCreateEvent` accepts an `entitySearch` making it the easiest migration path from the REST API. You can search by `name` as well as by `entityGuid` if you have it. If your existing REST integration only has the numeric application ID, you can resolve the entity directly with `entitySearch: { query: "domainId = 'YOUR_APP_ID' AND domain = 'APM'" }` — no GUID lookup needed. See the [Deployment by application ID example](/docs/change-tracking/config/nerdgraph/#deployment-by-appid) and [Track changes using NerdGraph](/docs/change-tracking/config/nerdgraph/) for all available fields.
 </Callout>
 
 ### Delete deployment
@@ -526,7 +541,7 @@ mutation {
 
 **NerdGraph:** There is no direct delete mutation for deployments in NerdGraph. Deployment records are immutable change tracking events.
 
-For more information, see [Track changes using NerdGraph](/docs/change-tracking/change-tracking-graphql/).
+For more information, see [Track changes using NerdGraph](/docs/change-tracking/config/nerdgraph/).
 
 ## Key transactions
 

--- a/src/content/docs/apm/apm-ui-pages/events/record-deployments.mdx
+++ b/src/content/docs/apm/apm-ui-pages/events/record-deployments.mdx
@@ -18,8 +18,14 @@ redirects:
 freshnessValidatedDate: never
 ---
 
-<Callout variant="important">
-  We recommend that you use the [change tracking](/docs/change-tracking/change-tracking-introduction/) feature instead of the older deployment markers. If you've been using deployment markers feature, you can still use it, but keep in mind that the change tracking feature is available for <InlinePopover type="browser"/> and <InlinePopover type="mobile"/>, as well as <InlinePopover type="apm"/>.
+<Callout title="The REST API for deployments is reaching end of life" variant="important">
+  The REST API v2 deployment endpoints (`/v2/applications/{app_id}/deployments.json`) documented on this page, along with the legacy Deployments v0 API, [reach end of life on July 31, 2027](/eol/2026/07/eol-07-31-26-rest-api-v2). After that date, they will no longer be available.
+
+  Record deployments with the [change tracking](/docs/change-tracking/change-tracking-introduction/) feature instead, using the NerdGraph `changeTrackingCreateEvent` mutation. For endpoint-by-endpoint mappings, see the [Migrate from REST API v2 to NerdGraph](/docs/apis/rest-api-v2/migrate-to-nerdgraph/#deployments) guide. The REST instructions below remain as reference for existing integrations you're migrating.
+</Callout>
+
+<Callout variant="tip">
+  Change tracking is available for <InlinePopover type="apm"/>, <InlinePopover type="browser"/>, and <InlinePopover type="mobile"/>.
 </Callout>
 
 Deploying an app can be a risky event—when your app breaks, and a bad deployment is often the cause. New Relic allows you to track deployments so you can correlate deployments with changes in your app's performance. Tracking deployments creates deployment markers that appear in APM charts and dashboards.
@@ -29,8 +35,7 @@ See how deployment markers work in this short video (4:30 minutes):
 
 ## Options for tracking deployments [#options]
 
-While you can use either the New Relic [REST API v2](/docs/apis/rest-api-v2/requirements/new-relic-rest-api-v2-getting-started) or [NerdGraph](/docs/change-tracking/change-tracking-graphql) to record new deployments and retrieve a list of past deployments, we recommend using NerdGraph.
-You can use the New Relic  to record new deployments and retrieve a list of past deployments. Additionally, some APM agents offer agent-specific methods to automatically record deployments.
+You can record new deployments and retrieve a list of past deployments with either the New Relic [REST API v2](/docs/apis/rest-api-v2/requirements/new-relic-rest-api-v2-getting-started) or [NerdGraph](/docs/change-tracking/config/nerdgraph/). Use NerdGraph: the REST API v2 deployment endpoints [reach end of life on July 31, 2027](/eol/2026/07/eol-07-31-26-rest-api-v2). Additionally, some APM agents offer agent-specific methods to automatically record deployments.
 
 You can use your [Slack](https://slack.com/) integration with New Relic, or a simple webhook, to notify your team in real time of deployments for applications monitored by APM. Slack provides a webhook URL that allows you to post generic JSON that will appear formatted in a chosen Slack channel.
 
@@ -50,8 +55,8 @@ There are a few places where you can view deployments in the New Relic UI after 
 
 ## Record deployments with the REST API [#api-instructions]
 
-<Callout variant="important">
-[NerdGraph](/docs/change-tracking/change-tracking-graphql) is the recommended API for querying New Relic data, retrieving account information, and configuring features. To explore its capabilities, check [the NerdGraph tutorials](/docs/apis/nerdgraph/get-started/introduction-new-relic-nerdgraph/#tutorials).
+<Callout title="These REST endpoints reach end of life July 31, 2027" variant="important">
+  The REST API v2 deployment endpoints shown below [reach end of life on July 31, 2027](/eol/2026/07/eol-07-31-26-rest-api-v2) and will stop working after that date. Migrate to the NerdGraph `changeTrackingCreateEvent` mutation — see the [Migrate from REST API v2 to NerdGraph](/docs/apis/rest-api-v2/migrate-to-nerdgraph/#deployments) guide. These instructions remain for reference while you migrate existing integrations.
 </Callout>
 
 You can use the New Relic REST API v2 to record deployments and get a list of past deployments.
@@ -312,14 +317,18 @@ You can use the New Relic REST API v2 to record deployments and get a list of pa
 
 ## Record deployments using the New Relic agent [#agent]
 
+<Callout variant="important">
+  The REST API v2 methods referenced below [reach end of life on July 31, 2027](/eol/2026/07/eol-07-31-26-rest-api-v2). Record deployments with the NerdGraph `changeTrackingCreateEvent` mutation instead — see the [migration guide](/docs/apis/rest-api-v2/migrate-to-nerdgraph/#deployments).
+</Callout>
+
 Some agents have additional methods to record deployments:
 
-* <DNT>**All agents**</DNT>: Use the New Relic [REST API v2](#api).
-* <DNT>**C**</DNT>: No SDK-specific methods. Use the [REST API](#api).
-* <DNT>**Go**</DNT>: No agent-specific methods. Use the [REST API](#api).
+* <DNT>**All agents**</DNT>: Use the New Relic [REST API v2](#api-instructions).
+* <DNT>**C**</DNT>: No SDK-specific methods. Use the [REST API](#api-instructions).
+* <DNT>**Go**</DNT>: No agent-specific methods. Use the [REST API](#api-instructions).
 * <DNT>**Java**</DNT>: Call the [Java agent `jar`](/docs/agents/java-agent/instrumentation/recording-deployments-java-agent).
 * <DNT>**.NET**</DNT>: Use [PowerShell and the REST API](#powershell).
-* <DNT>**Node.js**</DNT>: No agent-specific methods. Use the [REST API](#api).
+* <DNT>**Node.js**</DNT>: No agent-specific methods. Use the [REST API](#api-instructions).
 * <DNT>**PHP**</DNT>: Use a [PHP script](/docs/agents/php-agent/features/recording-deployments-using-php-script).
 * <DNT>**Python**</DNT>: Use the [`record-deploy`](/docs/agents/python-agent/installation-configuration/python-agent-admin-script#record-deploy) subcommand of the `newrelic-admin` script.
 * <DNT>**Ruby**</DNT>: Use a Capistrano recipe or the `newrelic deployments` command. More details [here](/docs/agents/ruby-agent/features/recording-deployments-ruby-agent).

--- a/src/content/docs/change-tracking/config/nerdgraph.mdx
+++ b/src/content/docs/change-tracking/config/nerdgraph.mdx
@@ -57,7 +57,60 @@ This method offers several benefits:
 * Broad visibility: You get a unified view of changes across all your accounts.
 * Easy to use: You don't need to know an `entity.guid`. This feature is powered by New Relic's flexible entity search.
 
-To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The events are stored in NRDB as [changeTrackingEvent](https://docs.newrelic.com/attribute-dictionary/?event=ChangeTrackingEvent) event type.
+To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The events are stored in NRDB as the [`ChangeTrackingEvent`](https://docs.newrelic.com/attribute-dictionary/?event=ChangeTrackingEvent) event type.
+
+### Search for an entity with entitySearch [#entity-search]
+
+The `changeTrackingCreateEvent` mutation takes an `entitySearch.query` argument to attach the change to a specific entity. You don't need to know the entity's GUID up front — you can search by other identifying attributes, including the numeric application ID you may already use with the REST APIs. This makes `entitySearch` the easiest migration path from the REST API, where you record deployments by application ID.
+
+An [entity](/docs/new-relic-solutions/new-relic-one/core-concepts/what-entity-new-relic/#what-is-entity) is a component that New Relic assigns a unique GUID to during instrumentation, such as an application or microservice.
+
+Your query must be specific enough to resolve to **exactly one entity**. If it matches more than one, the mutation fails; narrow it (for example, add `AND accountId = '<account id>'`).
+
+<Callout title="Migrating from the REST APIs?" variant="tip">
+  You don't need to look up an entity GUID first. Search by the numeric application ID you already use with `domainId = '<app id>' AND domain = 'APM'`. See the [Deployment by application ID](#deployment-by-appid) example below.
+</Callout>
+
+**Supported operators**
+
+The `=`, `AND`, `IN`, and `LIKE` operators are supported in entity search queries.
+
+**Special characters**
+
+Special characters — `(`, `.`, `,`, `;`, `:`, `*`, `-`, `_`, and `)` — are treated as whitespace in the query string. For example, `name LIKE ':aws:'` matches entity names containing `-aws` or `foo.aws`.
+
+**Attributes you can search on**
+
+You can filter on default entity properties and on tags (tags can be referenced with or without backticks):
+
+<table>
+  <thead>
+    <tr>
+      <th>Type</th>
+      <th>Values</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Default entity properties</td>
+      <td>`id`, `accountId`, `name`, `domainId`, `alertSeverity`, `reporting`, `indexedAt`, `firstIndexedAt`, `lastReportingChangeAt`</td>
+    </tr>
+    <tr>
+      <td>Tags (examples)</td>
+      <td>
+        * `language`: the agent language for APM applications
+        * `clusterAgentId`: for browser applications, links to the associated APM application's cluster agent
+        * `aws.accountId`: the AWS account ID for infrastructure entities monitored from AWS
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+**Examples**
+
+* Find an entity by its entity GUID: `"id = '<entity guid>'"`
+* Find an entity by its REST v2 API application ID: `"domainId = '<app id>' AND domain = 'APM'"`
+* Find an OpenTelemetry service in a specific account: `"name = '<service name>' AND domain = 'EXT' AND type = 'SERVICE' AND accountId = '<account id>'"`
 
 <CollapserGroup>
   <Collapser
@@ -96,50 +149,8 @@ To create an event, use the `changeTrackingCreateEvent` NerdGraph mutation. The 
           <td>`entitySearch.query`</td>
           <td>String</td>
           <td>
-
-            Find a specific entity within New Relic. You can search by using its specific entity guid using the `id` field or by providing other identifying information if the entity guid is unknown. An entity guid is a unique identifier that New Relic assigns to your system components such as applications or microservices during their instrumentation or setup. For more information about entities, refer to [New Relic Entities](/docs/new-relic-solutions/new-relic-one/core-concepts/what-entity-new-relic/#what-is-entity).
-
-            * Query specific entities: You can search for an exact or fuzzy matching on various attributes, including `id` and `name`, but your query must be specific enough to resolve to exactly one entity.
-
-            * Supported operators: The `=`, `AND`, `IN`, and `LIKE` operators are supported for entity search queries.
-
-            * Using special characters: Special characters such as `(`, `.` `,`, `;`, `:`, `*`,`-`, `_`, and `)` are treated as whitespace in the query string. For example, a query like `name LIKE ':aws:'` will match entity names containing `-aws` or `foo.aws`.
-            * Tags: You can reference tags with or without backticks. You can filter entities based on default entity properties and tags.
-
-                * Default entity properties:
-
-                    * `id`
-
-                    * `accountId`
-
-                    * `name`
-
-                    * `domainId`
-
-                    * `alertSeverity`
-
-                    * `reporting`
-
-                    * `indexedAt`
-
-                    * `firstIndexedAt`
-
-                    * `lastReportingChangeAt`
-
-                * Tags: Tags are metadata typically linked to a more specific domain type or group of domain types. For example:
-
-                    * `language`: Specifies the agent language for APM applications
-
-                    * `clusterAgentId`: For Browser applications, this tag links to the associated APM application's cluster agent.
-
-                    * `aws.accountId`: The `AWS account ID` for infrastructure entities monitored from AWS.
-
-                Examples:
-
-                    * To find an entity by its entity guid: `"id = '<entity guid>'"`
-                    * To find an entity using its REST v2 API application ID: `"domainId = '<app id>' AND domain = 'APM'"`
-                    * To find an OpenTelemetry service in a specific account: `"name = '<service name>' AND domain = 'EXT' AND type = 'SERVICE' AND accountId = '<account id>'"`
-            </td>
+            The entity to attach the change to, found with an entity search query. The query must resolve to exactly one entity, and supports the `=`, `AND`, `IN`, and `LIKE` operators — for example, `"id = '<entity guid>'"` or `"domainId = '<app id>' AND domain = 'APM'"`. For the full syntax, searchable attributes, and more examples, see [Search for an entity with entitySearch](#entity-search).
+          </td>
         </tr>
 
         <tr>
@@ -627,6 +638,53 @@ Here are example GraphQL mutations for creating change tracking events:
 
   <Collapser
     className="freq-link"
+    id="deployment-by-appid"
+    title="Deployment by application ID (migrating from the REST APIs)"
+  >
+    If you're migrating deployment recording from the REST API v2 (`/v2/applications/{app_id}/deployments.json`) or the Deployments v0 API, you already have the numeric application ID. You don't need to look up the entity GUID first — `entitySearch` can resolve the entity directly from the application ID using `domainId` and `domain`:
+
+    ```graphql
+        mutation {
+          changeTrackingCreateEvent(
+            changeTrackingEvent: {
+              categoryAndTypeData: {
+                categoryFields: {
+                  deployment: {
+                    version: "1.2.3"
+                    changelog: "Fixed authentication bug"
+                    commit: "abc123def456"
+                  }
+                }
+                kind: { category: "deployment", type: "basic" }
+              }
+              user: "deployer@example.com"
+              description: "Production deployment of auth fix"
+              entitySearch: { query: "domainId = 'YOUR_APP_ID' AND domain = 'APM'" }
+            }
+          ) {
+            changeTrackingEvent {
+              category
+              categoryAndType
+              changeTrackingId
+              description
+              entity {
+                name
+                guid
+              }
+              user
+            }
+            messages
+          }
+        }
+    ```
+
+    <Callout variant="tip">
+      Your `domainId` search must resolve to exactly one entity. If more than one application shares an ID across accounts, add `AND accountId = 'YOUR_ACCOUNT_ID'` to the query.
+    </Callout>
+  </Collapser>
+
+  <Collapser
+    className="freq-link"
     id="feature-flag-mutation"
     title="Feature flag event mutation"
   >
@@ -753,6 +811,17 @@ For change tracking events, these are the valid predefined category and type pai
 </Callout>
 
 Change tracking deployments provide specialized tracking for code deployments and infrastructure changes. This is the legacy method that focuses specifically on deployment events. You can create deployment markers using the `changeTrackingCreateDeployment` mutation. These markers are stored in NRDB as `Deployment` event type.
+
+<Callout title="Not affected by the REST API end-of-life" variant="important">
+  If you're here because of the REST API end-of-life announcement, note that the `changeTrackingCreateDeployment` NerdGraph mutation on this tab is **not** being retired and will continue to work.
+
+  What is reaching [end of life on July 31, 2027](/eol/2026/07/eol-07-31-26-rest-api-v2) are the *REST* deployment endpoints:
+
+  * The REST API v2 deployment endpoints (`https://api.newrelic.com/v2/applications/{app_id}/deployments.json`)
+  * The legacy Deployments v0 API (`deployments.xml`), served on both the `rpm` and `api` hosts in each region — `https://rpm.newrelic.com/deployments.xml` and `https://api.newrelic.com/deployments.xml` (US), plus their `.eu.` equivalents
+
+  If you record deployments through either of those REST APIs, migrate to NerdGraph change tracking before that date. `changeTrackingCreateEvent` (on the **Change tracking events** tab) is the recommended mutation to migrate to. For endpoint-by-endpoint mappings, see the [Migrate from REST API v2 to NerdGraph](/docs/apis/rest-api-v2/migrate-to-nerdgraph/#deployments) guide.
+</Callout>
 
 <Callout variant="tip">
   New Relic recommends migrating to change tracking events using `changeTrackingCreateEvent` for better flexibility and feature support. Deployment markers will continue to work but have limited functionality compared to change events.

--- a/src/content/docs/change-tracking/view-analyze-data.mdx
+++ b/src/content/docs/change-tracking/view-analyze-data.mdx
@@ -70,6 +70,118 @@ The <DNT>Change Tracking</DNT> across all entities page displays the change even
   src="/images/globalView.webp"
 />
 
+#### See how your changes are recorded across your estate [#recording-source]
+
+<Callout title="Preparing for the REST API end of life?" variant="tip">
+  The New Relic [Deployments v0 and v2 REST APIs reach end of life on July 31, 2027](/eol/2026/07/eol-07-31-26-rest-api-v2). If you record deployments through either of those REST APIs, use the approach below to find which of your existing changes came in through them (filter on `newrelic.source LIKE 'api.rest%'`), so you know what to migrate to NerdGraph before that date.
+</Callout>
+
+Every change tracking event records how it was created, so you can review the recording method and the calling client for all of your changes in one place — across every account and entity you have access to.
+
+Every event records a `newrelic.source` attribute, which identifies which change tracking API was used to create the event:
+
+<table>
+  <thead>
+    <tr>
+      <th>`newrelic.source`</th>
+      <th>How the change was recorded</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`api.graphql.changeTrackingCreateEvent`</td>
+      <td>NerdGraph `changeTrackingCreateEvent` mutation (recommended)</td>
+    </tr>
+    <tr>
+      <td>`api.graphql.changeTrackingCreateDeployment`</td>
+      <td>NerdGraph `changeTrackingCreateDeployment` mutation</td>
+    </tr>
+    <tr>
+      <td>`api.rest.deployments.v2`</td>
+      <td>REST API v2 deployments endpoint (`/v2/applications/{app_id}/deployments.json`) — reaching [end of life July 31, 2027](/eol/2026/07/eol-07-31-26-rest-api-v2)</td>
+    </tr>
+    <tr>
+      <td>`api.rest.deployments.v0`</td>
+      <td>Legacy Deployments v0 API (`deployments.xml`, served on the `rpm.newrelic.com` and `api.newrelic.com` hosts, and their `.eu.` equivalents) — reaching [end of life July 31, 2027](/eol/2026/07/eol-07-31-26-rest-api-v2)</td>
+    </tr>
+  </tbody>
+</table>
+
+Alongside `newrelic.source`, change tracking records details about the client that made the call:
+
+<table>
+  <thead>
+    <tr>
+      <th>Attribute</th>
+      <th>Description</th>
+      <th>Example</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>`instrumentation.provider`</td>
+      <td>A normalized value describing the code or tool that was detected to have sent the change event to New Relic. When the tool can't be determined, this is `unknown`.</td>
+      <td>`nerdgraph`, `newrelic-cli`, `axios`, `unknown`</td>
+    </tr>
+    <tr>
+      <td>`instrumentation.name`</td>
+      <td>A description of the telemetry that was used to determine `instrumentation.provider`: `newrelic` for change events sent through the NerdGraph mutations, or `user-agent` for change events sent through the REST APIs.</td>
+      <td>`newrelic`, `user-agent`</td>
+    </tr>
+    <tr>
+      <td>`instrumentation.source`</td>
+      <td>The underlying telemetry that `instrumentation.provider` was determined from. For `user-agent` data (REST APIs), this is the raw user agent string; for `newrelic` data (NerdGraph mutations), this is a normalized New Relic tool identifier.</td>
+      <td>`axios/1.18.1`, `newrelic-cli`</td>
+    </tr>
+    <tr>
+      <td>`instrumentation.language`</td>
+      <td>A normalized value describing the language of the tool that sent the change event, derived from `instrumentation.source` when one can be determined.</td>
+      <td>`Go`, `Java`, `Python`</td>
+    </tr>
+  </tbody>
+</table>
+
+<Callout variant="tip">
+  The `instrumentation.provider` and `instrumentation.source` values are your best signal for identifying the calling integration, but they aren't definitive — many tools share a generic value (for example, `curl` or a popular HTTP library). Treat them as a hint that narrows down where to look in your own systems, not a guaranteed identification.
+</Callout>
+
+**What you can use this for:**
+
+* **Audit how changes are recorded:** See which changes use NerdGraph (`changeTrackingCreateEvent` or `changeTrackingCreateDeployment`) versus the REST APIs across all your entities and accounts — for example, to standardize on a single method.
+* **Identify the tools recording changes:** Use `instrumentation.provider` and `instrumentation.source` to see which CI/CD systems, scripts, or libraries are recording changes across your estate.
+* **Check consistency across teams:** Facet by `newrelic.source` to see which recording method each entity or team uses — for example, to spot teams still recording through the REST APIs while others have moved to NerdGraph.
+* **Verify a migration:** After moving off the REST APIs, confirm no new changes are still arriving with an `api.rest.*` source.
+
+**In the UI:**
+
+1. Open the global view at <DNT>**[one.newrelic.com](https://one.newrelic.com) > All Capabilities > Change Tracking**</DNT>.
+2. Add columns such as entity name, `newrelic.source`, `user`, `instrumentation.provider`, `instrumentation.name`, `instrumentation.source`, and `instrumentation.language` so you can review each entry without opening it.
+3. Use the filter bar to narrow the change events table — for example, filter on `newrelic.source LIKE 'api.rest%'` to see only changes recorded through the REST APIs reaching end of life.
+
+**With NRQL:**
+
+Run this query in the [query builder](/docs/query-your-data/explore-query-data/query-builder/introduction-query-builder/) or through NerdGraph to see how changes are recorded across your estate, grouped by API and client:
+
+```sql
+FROM Deployment, ChangeTrackingEvent
+SELECT count(*)
+FACET newrelic.source, instrumentation.provider, instrumentation.name
+SINCE 3 months ago LIMIT MAX
+```
+
+To list the individual changes recorded through the REST APIs reaching end of life — with the caller's user agent, detected tool, and language — add the `api.rest%` filter:
+
+```sql
+FROM Deployment, ChangeTrackingEvent
+SELECT entity.name, version, user, newrelic.source, instrumentation.name, instrumentation.provider, instrumentation.source, instrumentation.language
+WHERE newrelic.source LIKE 'api.rest%'
+SINCE 3 months ago LIMIT MAX
+```
+
+<Callout variant="important">
+  This discovery method finds usage of the **deployment** REST APIs only. Other REST API v2 endpoints (for example, metric data, hosts, or alerts) don't record a `newrelic.source` attribute, and New Relic can't audit which of your tools call them. To find that usage, search your codebase, CI/CD pipelines, and automation scripts for calls to `api.newrelic.com/v2/` and `api.eu.newrelic.com/v2/`, as described in the [end-of-life announcement](/eol/2026/07/eol-07-31-26-rest-api-v2/#how-do-i-know-if-im-affected).
+</Callout>
+
 ### Entity-specific view [#entity-view]
 
 The entity-scoped Change Tracking view displays change events for a specific entity, such as APM, browser, or mobile. It also offers additional information related to golden signals for each change event. You can also use provided filters to view specific change events for that entity.

--- a/src/content/eol/2026/07/eol-07-31-26-rest-api-v2.md
+++ b/src/content/eol/2026/07/eol-07-31-26-rest-api-v2.md
@@ -17,7 +17,7 @@ The following API endpoints will be permanently retired on July 31, 2027:
 
 * `https://api.newrelic.com/v2/`: US datacenter (including the Alerts endpoints, `/v2/alerts*`, but excluding the retained conditions and policies namespaces listed under **Not impacted** below)
 * `https://api.eu.newrelic.com/v2/`: EU datacenter (including the Alerts endpoints, `/v2/alerts*`, but excluding the retained conditions and policies namespaces listed under **Not impacted** below)
-* `https://rpm.newrelic.com/deployments`: Legacy Deployments v0 API
+* Legacy Deployments v0 API (`deployments.xml`), which is served on both the `rpm` and `api` hosts in each region: `https://rpm.newrelic.com/deployments.xml` and `https://api.newrelic.com/deployments.xml` (US), and `https://rpm.eu.newrelic.com/deployments.xml` and `https://api.eu.newrelic.com/deployments.xml` (EU)
 
 ### Alerts
 
@@ -47,7 +47,7 @@ If you run into challenges with your migration please reach out to [Support](htt
 
 These API calls may originate from proprietary tools, reporting systems, or third-party integrations, and include any utilization of the affected Alerts endpoints (`/v2/alerts*`). To determine what action you need to take:
 
-1. **Identify your REST API v2 usage:** Search your codebase, CI/CD pipelines, and automation scripts for calls to `api.newrelic.com/v2/`, `api.eu.newrelic.com/v2/`, and `https://rpm.newrelic.com/deployments`
+1. **Identify your REST API v2 usage:** Search your codebase, CI/CD pipelines, and automation scripts for calls to `api.newrelic.com/v2/` and `api.eu.newrelic.com/v2/`, and for Deployments v0 API calls to `deployments.xml` on either the `rpm` or `api` host (for example, `rpm.newrelic.com/deployments.xml` or `api.newrelic.com/deployments.xml`, and their `.eu.` equivalents)
 
    Common integrations include:
 
@@ -59,6 +59,8 @@ These API calls may originate from proprietary tools, reporting systems, or thir
 
 3. **Review the migration guide:** For each REST API v2 call you identify, our [migration guide](https://docs.newrelic.com/docs/apis/rest-api-v2/migrate-to-nerdgraph/) provides the equivalent NerdGraph query or mutation.
 
+For **deployments** specifically, you don't have to rely on a codebase search alone. Change tracking adds a `newrelic.source` attribute to each deployment event, so you can find deployments still recorded through the Deployments v0 and v2 REST APIs across your whole estate — from the New Relic UI or with NRQL. See [how your changes are recorded across your estate](/docs/change-tracking/view-analyze-data/#recording-source). This applies to deployment endpoints only; for other REST API v2 endpoints, search your codebase as described above.
+
 ## What you need to do
 
 Migrate your integrations from REST API v2 to NerdGraph before July 31, 2027:
@@ -68,7 +70,7 @@ Migrate your integrations from REST API v2 to NerdGraph before July 31, 2027:
    * **Applications**: list, show, update, and delete via entity search and mutations
    * **Metric data**: query via NRQL, with a mapping table from REST API metric values to NRQL functions
    * **Hosts & instances**: query via NRQL with host faceting
-   * **Deployments**: record via `changeTrackingCreateDeployment` mutation, query via NRQL
+   * **Deployments**: record via the `changeTrackingCreateEvent` mutation (the recommended change tracking mutation), query via NRQL
    * **Key transactions**: query via entity search
    * **Mobile & browser applications**: query via entity search
 


### PR DESCRIPTION
## Give us some context

**What problems does this PR solve?**

The [REST API v2 and Deployments v0 API EOL announcement](https://docs.newrelic.com/eol/2026/07/eol-07-31-26-rest-api-v2/) (July 31, 2027) left several gaps for customers migrating their deployment integrations:

- The change tracking docs didn't warn readers that the REST deployment APIs are reaching EOL, and risked conflating the **`changeTrackingCreateDeployment` NerdGraph mutation** (not affected) with the **REST Deployments v0/v2 APIs** (affected).
- There was no documented, self-service way for customers to find *where* they still record deployments through the REST APIs.
- The `deployments.xml` v0 endpoint was documented inaccurately (bare path, single host).
- The primary "Record and view deployments" REST page had no EOL notice at all.

**What this PR does (5 files):**

- **`change-tracking/view-analyze-data`** — new "See how your changes are recorded across your estate" section: a cross-estate view of `newrelic.source` + `instrumentation.*` to find REST-recorded deployments, with UI + NRQL guidance. Attribute definitions aligned to the source-of-truth DACI and data dictionary.
- **`change-tracking/config/nerdgraph`** — disambiguation callout clarifying the `changeTrackingCreateDeployment` *mutation* is **not** part of the EOL; a new standalone "Search for an entity with entitySearch" section; an appId-based migration example; and a `ChangeTrackingEvent` capitalization fix.
- **`apis/rest-api-v2/migrate-to-nerdgraph`** — frames both the v0 and v2 REST deployment APIs, points at the discovery section and appId example, and recommends `changeTrackingCreateEvent`.
- **`apm/apm-ui-pages/events/record-deployments`** — EOL notices in four places on the primary REST deployment page; also fixes pre-existing broken `#api` anchors and a garbled sentence.
- **`eol/2026/07/eol-07-31-26-rest-api-v2`** — corrects the v0 endpoint to `deployments.xml` on all four hosts (`rpm`/`api` × US/EU, confirmed against live traffic), recommends `changeTrackingCreateEvent`, and links the new discovery method.

**Testing notes:**

- All new NRQL queries were run against a staging account to confirm they execute and return the documented fields.
- The `deployments.xml` endpoint/host list was confirmed against live `Transaction` data.
- Internal links use relative paths; NerdGraph links point at the canonical `/docs/change-tracking/config/nerdgraph/`.

**Related:** a companion PR corrects the shared `instrumentation.*` attribute definitions in the attribute-dictionary repo.

---

_Opened as a **draft** for review._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
