### PR TITLE
docs(gcp): add callout for GCP dashboard/alert migration tool

### DIFF
--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations.mdx
@@ -144,6 +144,10 @@ We recommend <DNT>**Workload Identity Federation**</DNT> for new integrations. I
 
 To learn about the permissions and roles New Relic needs to monitor your GCP services, see [Integrations and custom roles](/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles).
 
+<Callout variant="tip">
+  **Migrating dashboards and alerts?** If you have existing dashboards or alert conditions built on metric names from a New Relic service account or Google user account integration, use the [GCP migration tool](https://github.com/newrelic-experimental/gcp-queries-migration-tool) to automatically convert your NRQL queries to the dimensional metric names used by Workload Identity Federation.
+</Callout>
+
 ## Setup guides [#setup-guides]
 
 - **Workload Identity Federation (Recommended)**

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations.mdx
@@ -145,7 +145,7 @@ We recommend <DNT>**Workload Identity Federation**</DNT> for new integrations. I
 To learn about the permissions and roles New Relic needs to monitor your GCP services, see [Integrations and custom roles](/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles).
 
 <Callout variant="tip">
- If you've existing dashboards or alert conditions built on metric names from a New Relic service account or Google user account integration, use the [GCP migration tool](https://github.com/newrelic-experimental/gcp-queries-migration-tool) to automatically convert your NRQL queries to the dimensional metric names used by Workload Identity Federation.
+ If you've existing dashboards or alert conditions built on metric names from a New Relic service account or Google user account integration, use the [GCP migration tool](https://github.com/newrelic-experimental/gcp-queries-migration-tool) to automatically convert your NRQL queries to the dimensional metric names used by Workload Identity Federation. 
 </Callout>
 
 ## Setup guides [#setup-guides]

--- a/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations.mdx
+++ b/src/content/docs/infrastructure/google-cloud-platform-integrations/get-started/introduction-google-cloud-platform-integrations.mdx
@@ -145,7 +145,7 @@ We recommend <DNT>**Workload Identity Federation**</DNT> for new integrations. I
 To learn about the permissions and roles New Relic needs to monitor your GCP services, see [Integrations and custom roles](/docs/infrastructure/google-cloud-platform-integrations/get-started/integrations-custom-roles).
 
 <Callout variant="tip">
-  **Migrating dashboards and alerts?** If you have existing dashboards or alert conditions built on metric names from a New Relic service account or Google user account integration, use the [GCP migration tool](https://github.com/newrelic-experimental/gcp-queries-migration-tool) to automatically convert your NRQL queries to the dimensional metric names used by Workload Identity Federation.
+ If you've existing dashboards or alert conditions built on metric names from a New Relic service account or Google user account integration, use the [GCP migration tool](https://github.com/newrelic-experimental/gcp-queries-migration-tool) to automatically convert your NRQL queries to the dimensional metric names used by Workload Identity Federation.
 </Callout>
 
 ## Setup guides [#setup-guides]


### PR DESCRIPTION
## Summary
- Adds a callout on the GCP integrations introduction page pointing customers with existing dashboards/alerts built on service account or user account metric names to the new open-source [gcp-queries-migration-tool](https://github.com/newrelic-experimental/gcp-queries-migration-tool), which converts NRQL queries to the dimensional metric names used by Workload Identity Federation.
- Placed just above the "Setup guides" section per @rshaik's guidance in Slack.
- Avoids internal "V1/V2" terminology; frames the change as migrating from service account/user account auth to WIF-based auth, per feedback in the thread.

Context: https://newrelic.slack.com/archives/C09Q0CWQUEQ/p1789037518831469

## Test plan
- [ ] Preview build renders the callout correctly on the GCP introduction page
- [ ] Link to the migration tool resolves correctly